### PR TITLE
Fixed the name of the function 'get_license' to 'get_licence' within rpc_methods_general

### DIFF
--- a/src/ansys/motorcad/core/methods/rpc_methods_general.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_general.py
@@ -420,7 +420,7 @@ class _RpcMethodsGeneral:
     def get_license(self):
         """Check if there is a licence available for the current context and machine type.
 
-        Deprecated function, replaced by get_licence
+        Deprecated function. Replaced by :func:`MotorCAD.get_licence`.
         """
         method = "GetLicence"
         return self.get_licence()

--- a/src/ansys/motorcad/core/rpc_methods_core_old.py
+++ b/src/ansys/motorcad/core/rpc_methods_core_old.py
@@ -106,8 +106,8 @@ class _RpcMethodsCoreOld:
         return replacement_function(*args)
 
     def GetLicence(self):
-        """Deprecated function. Replaced by :func:`MotorCAD.get_license`."""
-        replacement_function = self.new_methods.get_license
+        """Deprecated function. Replaced by :func:`MotorCAD.get_licence`."""
+        replacement_function = self.new_methods.get_licence
         deprecation_warning(_getframe().f_code.co_name, replacement_function.__name__)
         return replacement_function()
 


### PR DESCRIPTION
Added correctly spelled function 'get_licence'
Kept incorrectly spelled function 'get_license', but edited so that this calls 'get_licence' with a note to say that this is deprecated