### PR TITLE
Doc/add cheat sheet links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,27 @@ PyMotorCAD
 
 This Python package provides the core Python RPC-JSON interface for Motor-CAD.
 
+Documentation and issues
+------------------------
+Documentation for the latest stable release of PyMotorCAD is hosted at
+`PyMotorCAD documentation <https://motorcad.docs.pyansys.com/version/stable/>`_.
+
+In the upper right corner of the documentation's title bar, there is an option for switching from
+viewing the documentation for the latest stable release to viewing the documentation for the
+development version or previously released versions.
+
+You can also `view <https://cheatsheets.docs.pyansys.com/pymotorcad_cheat_sheet.png>`_ or
+`download <https://cheatsheets.docs.pyansys.com/pyfluent_cheat_sheet.pdf>`_ the
+PyMotorCAD cheat sheet. This one-page reference provides syntax rules and commands
+for using PyMotorCAD. 
+
+On the `PyFluent Issues <https://github.com/ansys/pyfluent/issues>`_ page, you can create
+issues to report bugs and request new features. On the `PyFluent Discussions
+<https://github.com/ansys/pyfluent/discussions>`_ page or the `Discussions <https://discuss.ansys.com/>`_
+page on the Ansys Developer portal, you can post questions, share ideas, and get community feedback. 
+
+To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
+
 Install the package
 -------------------
 
@@ -41,7 +62,7 @@ PyMotorCAD has two installation modes: user and developer.
 Install in user mode
 ^^^^^^^^^^^^^^^^^^^^
 
-Before installing PyMotorCAD in user mode, run this command to esure
+Before installing PyMotorCAD in user mode, run this command to ensure
 that you have the latest version of `pip`_:
 
 .. code:: bash
@@ -60,10 +81,8 @@ Install in developer mode
 Installing PyMotorCAD in developer mode allows
 you to modify the source and enhance it.
 
-.. note::
-
-    Before contributing to this project, ensure that you are familiar
-    with all guidelines in the `PyAnsys Developer's Guide`_.
+**Note:** Before contributing to this project, ensure that you are familiar
+with all guidelines in the `PyAnsys Developer's Guide`_.
     
 To install in developer mode, complete these steps:
 
@@ -73,8 +92,8 @@ To install in developer mode, complete these steps:
 
         git clone https://github.com/ansys/pymotorcad
 
-#. Create a fresh-clean Python environment and activate it with
-   these commands:
+#. Create a fresh-clean Python environment and then activate it with these
+   commands:
 
     .. code:: bash
 
@@ -133,8 +152,8 @@ Here are commands for running various checks in the  ``tox`` environment:
 Raw testing
 ^^^^^^^^^^^
 
-If required, you can call style commands, including `black`_, `isort`_,
-and `flake8`_ or unit testing commands like`pytest`_ from the command line.
+If required, you can call style commands, such as `black`_, `isort`_,
+and `flake8`_, or unit testing commands, such as`pytest`_, from the command line.
 However, using these commands does not guarantee that your project is being
 tested in an isolated environment, which is why tools like `tox`_ exist.
 
@@ -150,8 +169,8 @@ encouraged to install this tool by running this command:
     python -m pip install pre-commit && pre-commit install
 
 
-Documentation
--------------
+Documentation builds
+--------------------
 
 To build documentation, you can run the usual rules provided in the
 `Sphinx`_ Makefile with a command like this:
@@ -161,21 +180,18 @@ To build documentation, you can run the usual rules provided in the
     make -C doc/ html && your_browser_name doc/html/index.html
 
 However, the recommended way of checking documentation integrity is to use
-this ``tox`` command:
+a ``tox`` command like this:
 
 .. code:: bash
 
     tox -e doc && your_browser_name .tox/doc_out/index.html
 
 
-For more information, see the `Documentation <https://motorcad.docs.pyansys.com/>`_
-page in the PyMotorCAD documentation.
-
 Distribution
 ------------
 
 If you would like to create either source or wheel files, run the following
-code to install the building requirements and execute the build module:
+commands to install the building requirements and execute the build module:
 
 .. code:: bash
 
@@ -183,13 +199,16 @@ code to install the building requirements and execute the build module:
     python -m build
     python -m twine check dist/*
 
+
+
+
 .. LINKS AND REFERENCES
 .. _black: https://github.com/psf/black
 .. _flake8: https://flake8.pycqa.org/en/latest/
 .. _isort: https://github.com/PyCQA/isort
 .. _pip: https://pypi.org/project/pip/
 .. _pre-commit: https://pre-commit.com/
-.. _PyAnsys Developer's guide: https://dev.docs.pyansys.com/
+.. _PyAnsys Developer's Guide: https://dev.docs.pyansys.com/
 .. _pytest: https://docs.pytest.org/en/stable/
 .. _Sphinx: https://www.sphinx-doc.org/en/master/
 .. _tox: https://tox.wiki/

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ On the `PyMotorCAD Issues <https://github.com/ansys/pymotorcad/issues>`_ page, y
 issues to report bugs and request new features. On the `Discussions <https://discuss.ansys.com/>`_
 page on the Ansys Developer portal, you can post questions, share ideas, and get community feedback. 
 
-To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
+To reach the project support team, email `pyansys.core@ansys.com <mailto:pyansys.core@ansys.com>`_.
 
 Installation
 ------------
@@ -214,7 +214,7 @@ License and acknowledgements
 ----------------------------
 
 PyMotorCAD is licensed under the MIT license. For more information, see the
-[LICENSE](https://github.com/ansys/pymotorcad/raw/main/LICENSE) file.
+`LICENSE <https://github.com/ansys/pymotorcad/raw/main/LICENSE>`_: file.
 
 PyMotorCAD makes no commercial claim over Ansys whatsoever. This library
 extends the capability of Ansys Motor-CAD by adding a Python interface

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,18 @@ PyMotorCAD
    :alt: Black
 
 
-This Python package provides the core Python RPC-JSON interface for Motor-CAD.
+Overview
+--------
+
+Ansys Motor-CAD is a dedicated design and analysis tool for electric motors. It enables rapid
+and accurate multiphysics design and analysis of electric machines across the full-operating
+spectrum.
+
+PyMotorCAD uses a Python JSON-RPC (remote procedure call) interface for
+Motor-CAD to launch or connect with a Motor-CAD instance, either locally or
+from a remote machine via HTTP. With PyMotorCAD, you can programmatically
+create, interact with, and control a Motor-CAD model, with or without using
+the Motor-CAD GUI.
 
 Documentation and issues
 ------------------------
@@ -43,19 +54,18 @@ viewing the documentation for the latest stable release to viewing the documenta
 development version or previously released versions.
 
 You can also `view <https://cheatsheets.docs.pyansys.com/pymotorcad_cheat_sheet.png>`_ or
-`download <https://cheatsheets.docs.pyansys.com/pyfluent_cheat_sheet.pdf>`_ the
+`download <https://cheatsheets.docs.pyansys.com/pymotorcad_cheat_sheet.pdf>`_ the
 PyMotorCAD cheat sheet. This one-page reference provides syntax rules and commands
 for using PyMotorCAD. 
 
-On the `PyFluent Issues <https://github.com/ansys/pyfluent/issues>`_ page, you can create
-issues to report bugs and request new features. On the `PyFluent Discussions
-<https://github.com/ansys/pyfluent/discussions>`_ page or the `Discussions <https://discuss.ansys.com/>`_
+On the `PyMotorCAD Issues <https://github.com/ansys/pymotorcad/issues>`_ page, you can create
+issues to report bugs and request new features. On the `Discussions <https://discuss.ansys.com/>`_
 page on the Ansys Developer portal, you can post questions, share ideas, and get community feedback. 
 
 To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
 
-Install the package
--------------------
+Installation
+------------
 
 PyMotorCAD has two installation modes: user and developer.
 
@@ -200,7 +210,20 @@ commands to install the building requirements and execute the build module:
     python -m twine check dist/*
 
 
+License and acknowledgements
+----------------------------
 
+PyMotorCAD is licensed under the MIT license. For more information, see the
+[LICENSE](https://github.com/ansys/pymotorcad/raw/master/LICENSE) file.
+
+PyMotorCAD makes no commercial claim over Ansys whatsoever. This library
+extends the capability of Ansys Motor-CAD by adding a Python interface
+to Motor-CAD without changing the core behaviour or license of the original
+software. Using PyMotorCAD for interactive control of Motor-CAD requires
+a legally licensed copy of Motor-CAD.
+
+For more information on Motor-CAD, see the `Ansys Motor-CAD <https://www.ansys.com/products/electronics/ansys-motor-cad>`_
+page on the Ansys website.
 
 .. LINKS AND REFERENCES
 .. _black: https://github.com/psf/black

--- a/README.rst
+++ b/README.rst
@@ -214,7 +214,7 @@ License and acknowledgements
 ----------------------------
 
 PyMotorCAD is licensed under the MIT license. For more information, see the
-[LICENSE](https://github.com/ansys/pymotorcad/raw/master/LICENSE) file.
+[LICENSE](https://github.com/ansys/pymotorcad/raw/main/LICENSE) file.
 
 PyMotorCAD makes no commercial claim over Ansys whatsoever. This library
 extends the capability of Ansys Motor-CAD by adding a Python interface

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -79,31 +79,26 @@ Features of PyMotorCAD include:
 - Customizable example scripts for common or advanced workflows, both within
   Motor-CAD and involving the coupling of Motor-CAD to other software.
 
+
 Documentation and issues
--------------------------
+------------------------
+Documentation for the latest stable release of PyMotorCAD is hosted at
+`PyMotorCAD documentation <https://motorcad.docs.pyansys.com/version/stable/>`_.
 
-The `PyMotorCAD documentation <https://motorcad.docs.pyansys.com/version/stable/>`_
-provides installation and usage information.
+In the upper right corner of the documentation's title bar, there is an option for switching from
+viewing the documentation for the latest stable release to viewing the documentation for the
+development version or previously released versions.
 
-On the `PyMotorCAD Issues <https://github.com/ansys/pymotorcad/issues>`_
-page, you can create issues to submit questions, report bugs, and request
-new features.
+You can also `view <https://cheatsheets.docs.pyansys.com/pymotorcad_cheat_sheet.png>`_ or
+`download <https://cheatsheets.docs.pyansys.com/pymotorcad_cheat_sheet.pdf>`_ the
+PyMotorCAD cheat sheet. This one-page reference provides syntax rules and commands
+for using PyMotorCAD. 
+
+On the `PyMotorCAD Issues <https://github.com/ansys/pymotorcad/issues>`_ page, you can create
+issues to report bugs and request new features. On the `Discussions <https://discuss.ansys.com/>`_
+page on the Ansys Developer portal, you can post questions, share ideas, and get community feedback. 
 
 To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
-
-
-License
--------
-PyMotorCAD is licensed under the MIT license.
-
-PyMotorCAD makes no commercial claim over Ansys whatsoever. This library
-extends the capability of Ansys Motor-CAD by adding a Python interface
-to Motor-CAD without changing the core behaviour or license of the original
-software. Using PyMotorCAD for interactive control of Motor-CAD requires
-a legally licensed copy of Motor-CAD.
-
-For more information on Motor-CAD, see the `Ansys Motor-CAD <https://www.ansys.com/products/electronics/ansys-motor-cad>`_
-page on the Ansys website.
 
 Project index
 --------------


### PR DESCRIPTION
Per Landon’s request in the PyAnsys Global AFT on 7/26/23, add links to the PyMotorCAD cheat sheet from this library's documentation.

Note: This library doesn't reuse the README content in the overall index.rst file for documentation. Consequently, I revised the "Documentation and issues" section in both the README and the overall index.rst file.