### PR TITLE
Add new option when connecting to Motor-CAD to keep_instance_open

### DIFF
--- a/src/ansys/motorcad/core/motorcad_methods.py
+++ b/src/ansys/motorcad/core/motorcad_methods.py
@@ -17,6 +17,7 @@ class _MotorCADCore(_RpcMethodsCore, _RpcMethodsUtility):
         enable_exceptions=True,
         enable_success_variable=False,
         reuse_parallel_instances=False,
+        keep_instance_open=False,
         url="",
         timeout=2,
     ):
@@ -26,6 +27,7 @@ class _MotorCADCore(_RpcMethodsCore, _RpcMethodsUtility):
             enable_exceptions,
             enable_success_variable,
             reuse_parallel_instances,
+            keep_instance_open,
             url=url,
             timeout=timeout,
         )
@@ -48,8 +50,10 @@ class MotorCAD(_MotorCADCore):
     enable_success_variable : Boolean, default: False
         Whether Motor-CAD methods return a success variable (first object in tuple).
     reuse_parallel_instances : Boolean, default: False
-        Whether to reuse MotorCAD instances when running in parallel. You must
+        Whether to reuse Motor-CAD instances when running in parallel. You must
         free instances after use.
+    keep_instance_open : Boolean, default: False
+        Whether to keep the Motor-CAD instance open after the instance becomes free.
     url: string, default = ""
         Full url for Motor-CAD connection. Assumes we are connecting to existing instance.
     Returns
@@ -64,6 +68,7 @@ class MotorCAD(_MotorCADCore):
         enable_exceptions=True,
         enable_success_variable=False,
         reuse_parallel_instances=False,
+        keep_instance_open=False,
         url="",
     ):
         """Initiate MotorCAD object."""
@@ -74,6 +79,7 @@ class MotorCAD(_MotorCADCore):
             enable_exceptions=enable_exceptions,
             enable_success_variable=enable_success_variable,
             reuse_parallel_instances=reuse_parallel_instances,
+            keep_instance_open=keep_instance_open,
             url=url,
         )
 
@@ -98,6 +104,7 @@ class MotorCADCompatibility(_RpcMethodsCoreOld):
         enable_exceptions=False,
         enable_success_variable=True,
         reuse_parallel_instances=False,
+        keep_instance_open=False,
     ):
         """Create MotorCADCompatibility object."""
         self.connection = _MotorCADConnection(
@@ -106,6 +113,7 @@ class MotorCADCompatibility(_RpcMethodsCoreOld):
             enable_exceptions=enable_exceptions,
             enable_success_variable=enable_success_variable,
             reuse_parallel_instances=reuse_parallel_instances,
+            keep_instance_open=keep_instance_open,
             compatibility_mode=True,
         )
 

--- a/src/ansys/motorcad/core/rpc_client_core.py
+++ b/src/ansys/motorcad/core/rpc_client_core.py
@@ -156,6 +156,7 @@ class _MotorCADConnection:
         enable_exceptions,
         enable_success_variable,
         reuse_parallel_instances,
+        keep_instance_open,
         url="",
         timeout=2,
         compatibility_mode=False,
@@ -175,6 +176,8 @@ class _MotorCADConnection:
         reuse_parallel_instances: Boolean
             Whether to reuse MotorCAD instances when running in parallel. You must free
             instances after use.
+        keep_instance_open : Boolean, default: False
+            Whether to keep the Motor-CAD instance open after the instance becomes free.
         compatibility_mode: Boolean, default: False
             Whether to try to run an old script written for ActiveX.
         url: string, default = ""
@@ -192,6 +195,8 @@ class _MotorCADConnection:
 
         self.enable_exceptions = enable_exceptions
         self.reuse_parallel_instances = reuse_parallel_instances
+
+        self.keep_instance_open = keep_instance_open
 
         self._open_new_instance = open_new_instance
 
@@ -306,7 +311,11 @@ class _MotorCADConnection:
             and (self._compatibility_mode is False)
         ):
             # Local Motor-CAD has been launched by Python
-            return True
+            if self.keep_instance_open is True:
+                return False
+            else:
+                return True
+                # keep the instance open if specified
         elif _HAS_PIM and pypim.is_configured():
             # Always try to close Ansys Lab instance
             return True

--- a/tests/test_rpc_client_core.py
+++ b/tests/test_rpc_client_core.py
@@ -106,6 +106,27 @@ def test_reusing_parallel_instances():
     mc3.set_free()
 
 
+# test keeping an instance open
+def test_keeping_instance_open():
+    # This should connect to mc test instance
+    mc2 = MotorCAD(keep_instance_open=True)
+
+    original_port = mc2.connection._port
+
+    # finished with this instance
+    del mc2
+
+    # connect to the same instance (if it is still open)
+    mc3 = pymotorcad.MotorCAD(open_new_instance=False)
+
+    # check the instance is the same as before
+    assert mc3.connection._port == original_port
+
+    mc3.quit()
+
+    del mc3
+
+
 # Check that Motor-CAD closes when Motor-CAD object is freed
 def test_deleting_object():
     mc3 = MotorCAD(open_new_instance=True)


### PR DESCRIPTION
Once the instance is done with (script finished) we can choose to keep the instance open. Previously had to use reuse_parallel_instances for this option, but that has additional functionality which could cause problems.