### PR TITLE
Correct docstrings for geometry.unite

### DIFF
--- a/src/ansys/motorcad/core/geometry.py
+++ b/src/ansys/motorcad/core/geometry.py
@@ -261,7 +261,7 @@ class Region(object):
             return regions[1 : len(regions)]
 
     def unite(self, regions):
-        """Subtract region from self, returning any additional regions.
+        """Unite one or more other regions with self.
 
         Parameters
         ----------


### PR DESCRIPTION
I noticed that the geometry 'unite' function had an incorrect docstring, copied from 'subtract'.