### PR TITLE
Corrected calculation of arc length

### DIFF
--- a/src/ansys/motorcad/core/geometry.py
+++ b/src/ansys/motorcad/core/geometry.py
@@ -1164,19 +1164,7 @@ class _BaseArc(Entity):
         float
             Length of arc
         """
-        radius, angle_1 = xy_to_rt(self.start.x, self.start.y)
-        radius, angle_2 = xy_to_rt(self.end.x, self.end.y)
-
-        if self.radius == 0:
-            arc_angle = 0
-        elif ((self.radius > 0) and (angle_1 > angle_2)) or (
-            (self.radius < 0) and angle_2 < angle_1
-        ):
-            arc_angle = angle_2 - (angle_1 - 360)
-        else:
-            arc_angle = angle_2 - angle_1
-
-        return self.radius * radians(arc_angle)
+        return abs(self.radius * radians(self.total_angle))
 
     def reverse(self):
         """Reverse Arc entity."""

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -558,6 +558,11 @@ def test_arc_length():
 
     assert arc.length == math.pi
 
+    radius = 45
+    line_1 = Line(Coordinate(62, 20), Coordinate(56, 33))
+    arc_2 = Arc(Coordinate(62, 20), Coordinate(56, 33), radius=radius)
+    assert arc_2.length > line_1.length
+
 
 def test_convert_entities_to_json():
     raw_entities = [


### PR DESCRIPTION
previous arc length calculation had problems, replaced with a simpler calculation that relies of the total_angle() class method/property of arcs