### PR TITLE
Include geometry_drawing in docs

### DIFF
--- a/doc/source/methods/geometry_drawing.rst
+++ b/doc/source/methods/geometry_drawing.rst
@@ -1,0 +1,14 @@
+.. _ref_geometry_drawing:
+.. currentmodule:: ansys.motorcad.core.geometry_drawing
+Geometry drawing
+================
+Geometry drawing functions are used to visualise Motor-CAD
+geometry objects using PyMotorCAD.
+More information on Adaptive Templates is available
+in the :ref:`ref_user_guide` under :ref:`ref_adaptive_templates_UG`.
+
+.. autosummary::
+   :toctree: _autosummary_geometry_drawing
+
+   draw_objects
+   draw_objects_debug

--- a/doc/source/methods/geometry_functions.rst
+++ b/doc/source/methods/geometry_functions.rst
@@ -29,9 +29,3 @@ Geometry functions
    get_entities_have_common_coordinate
    xy_to_rt
    rt_to_xy
-
-.. currentmodule:: ansys.motorcad.core.geometry_drawing
-.. autosummary::
-   :toctree: _autosummary_geometry_functions
-
-   draw_regions

--- a/doc/source/methods/index.rst
+++ b/doc/source/methods/index.rst
@@ -32,6 +32,14 @@ Geometry objects and functions are used for
 defining and modifying Adaptive Templates geometries in Python.
 For descriptions of the objects and functions, see :ref:`ref_geometry_functions`.
 
+Geometry drawing
+------------------------------
+The ``ansys.motorcad.core.geometry_drawing`` library contains functions for drawing
+geometry objects as static visualisations in Python. Geometry drawing is used for plotting
+objects such as regions, lines, arcs and coordinates within the x-y plane. Drawing Motor-CAD
+geometry objects can make it easier to test and create Adaptive Templates scripts.
+For descriptions of the geometry drawing functions, see :ref:`ref_geometry_drawing`.
+
 Geometry shapes
 ------------------------------
 The ``ansys.motorcad.core.geometry_shapes`` library contains geometry functions
@@ -47,4 +55,5 @@ For descriptions of the functions, see :ref:`ref_geometry_shapes`.
    MotorCAD_object
    MotorCADCompatibility_object
    geometry_functions
+   geometry_drawing
    geometry_shapes


### PR DESCRIPTION
Add Geometry Drawing methods to Docs (previously missing)
Removes 'draw_regions' from geometry_functions Doc because this is deprecated and made obsolete by draw_objects