### PR TITLE
Fix sphinx gallery thumbnails

### DIFF
--- a/examples/adaptive_library/BPMTriangularRotorNotches.py
+++ b/examples/adaptive_library/BPMTriangularRotorNotches.py
@@ -51,7 +51,7 @@ improve NVH performance.
 # create the notch geometry region with Adaptive Templates geometry. Import the ``os``, ``shutil``,
 # ``sys``, and ``tempfile`` packages to open and save a temporary MOT file if none is open.
 
-# sphinx_gallery_thumbnail_number = -1
+# sphinx_gallery_thumbnail_path = 'images/BPMTriangularRotorNotches.png'
 import os
 import shutil
 import sys

--- a/examples/adaptive_library/BezierCurveRotorPockets.py
+++ b/examples/adaptive_library/BezierCurveRotorPockets.py
@@ -40,7 +40,7 @@ with a custom curve defined using a Bezier function.
 # Import the ``os``, ``shutil``, ``sys`` and ``tempfile`` packages
 # to open and save a temporary MOT file if none is open.
 
-# sphinx_gallery_thumbnail_number = -1
+# sphinx_gallery_thumbnail_path = 'images/Adaptive_Geometry_Bezier_e4a_3.png'
 import os
 import shutil
 import sys

--- a/examples/adaptive_library/TrapezoidalDuct.py
+++ b/examples/adaptive_library/TrapezoidalDuct.py
@@ -13,7 +13,7 @@ into trapezoidal ducts.
 # Import ``os``, ``shutil``, ``sys``, and ``tempfile``
 # to open and save a temporary .mot file if none is open.
 
-# sphinx_gallery_thumbnail_number = -1
+# sphinx_gallery_thumbnail_path = 'images/TrapezoidalDuct1.png'
 import os
 import shutil
 import sys

--- a/examples/adaptive_library/UShapeSYNCRELCurvedFluxBarriers.py
+++ b/examples/adaptive_library/UShapeSYNCRELCurvedFluxBarriers.py
@@ -52,7 +52,7 @@ use curved rotor pockets.
 # Import ``os``, ``shutil``, ``sys``, and ``tempfile``
 # to open and save a temporary .mot file if none is open.
 
-# sphinx_gallery_thumbnail_number = -1
+# sphinx_gallery_thumbnail_path = 'images/UShapeSYNCRELCurvedFluxBarriers.png'
 import os
 import shutil
 import sys


### PR DESCRIPTION
Does what it says on the tin.

Before:
![image](https://github.com/user-attachments/assets/f0709b88-05f8-4996-ade8-db474ee6ac91)

After:
![image](https://github.com/user-attachments/assets/014db90f-20de-49ae-b134-989d0237d2c3)
