### PR TITLE
#430 method to extract harmonic data from transient results

### DIFF
--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -169,6 +169,24 @@ def test_get_magnetic_3d_graph(mc):
     assert almost_equal(graph_result.data[1][1], y)
 
 
+def test_get_magnetic_graph_harmonics(mc):
+    reset_to_default_file(mc)
+
+    mc.set_variable("TorqueCalculation", True)
+    mc.set_variable("ElectromagneticForcesCalc_Load", True)
+
+    mc.do_magnetic_calculation()
+    orders, amp, ang = mc.get_magnetic_graph_harmonics("PhaseCurrent1")
+    amplitude_expected = mc.get_variable("PeakCurrent")
+    phase_expected = mc.get_variable("PhaseAdvance") - 90
+    assert len(orders) == 2
+    assert len(amp) == 2
+    assert len(ang) == 2
+    assert orders[1] == 1
+    assert almost_equal(amp[1], amplitude_expected)
+    assert almost_equal(ang[1], phase_expected)
+
+
 #   #Not fully ready submitted an issue
 # def test_get_fea_graph_point():
 #     reset_to_default_file(mc)


### PR DESCRIPTION
This implements a method to give the user the harmonic orders, amplitudes and phase angles from a magnetic graph. These are currently easily visible in Motor-CAD, but hard to access via PyMotorCAD.

Closes #430 

Example code to test with:
```
import ansys.motorcad.core as pym
import matplotlib.pyplot as plt

mc = pym.MotorCAD(open_new_instance=False)

orders, amp, ang = mc.get_magnetic_graph_harmonics("TerminalLineToLine12")
# orders, amp, ang = mc.get_magnetic_graph_harmonics("CoggingTorqueVW")
# orders, amp, ang = mc.get_magnetic_graph_harmonics("PhaseCurrent1")

fig, axs = plt.subplots(2)
axs[0].bar(orders, amp)
axs[1].bar(orders, ang)
plt.show()
```