### PR TITLE
Add set_adaptive_parameter_default method

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
+Copyright (c) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/examples/adaptive_library/BPMTriangularRotorNotches.py
+++ b/examples/adaptive_library/BPMTriangularRotorNotches.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #
@@ -127,23 +127,11 @@ mc.reset_adaptive_geometry()
 # If the Adaptive Parameters have already been set in the current Motor-CAD file, their current
 # values will be used. Otherwise, the Adaptive Parameters will be defined and set to default values.
 #
-# The function ``set_default_parameter`` is defined to check if a parameter exists, and if not,
-# create it with a default value.
-
-
-def set_default_parameter(parameter_name, default_value):
-    try:
-        mc.get_adaptive_parameter_value(parameter_name)
-    except pymotorcad.MotorCADError:
-        mc.set_adaptive_parameter_value(parameter_name, default_value)
-
-
-# %%
-# Use the ``set_default_parameter`` to set the required parameters if undefined
-set_default_parameter("Notch Angle", -4)
-set_default_parameter("Notch Sweep", 5)
-set_default_parameter("Notch Depth", 1)
-set_default_parameter("Notches per Pole", 2)
+# Use the ``set_adaptive_parameter_default`` to set the required parameters if undefined
+mc.set_adaptive_parameter_default("Notch Angle", -4)
+mc.set_adaptive_parameter_default("Notch Sweep", 5)
+mc.set_adaptive_parameter_default("Notch Depth", 1)
+mc.set_adaptive_parameter_default("Notches per Pole", 2)
 
 
 # %%

--- a/examples/adaptive_library/BPMTriangularRotorNotches.py
+++ b/examples/adaptive_library/BPMTriangularRotorNotches.py
@@ -127,7 +127,7 @@ mc.reset_adaptive_geometry()
 # If the Adaptive Parameters have already been set in the current Motor-CAD file, their current
 # values will be used. Otherwise, the Adaptive Parameters will be defined and set to default values.
 #
-# Use the ``set_adaptive_parameter_default`` to set the required parameters if undefined
+# Use the ``set_adaptive_parameter_default`` method to set the required parameters if undefined.
 mc.set_adaptive_parameter_default("Notch Angle", -4)
 mc.set_adaptive_parameter_default("Notch Sweep", 5)
 mc.set_adaptive_parameter_default("Notch Depth", 1)

--- a/examples/adaptive_library/BezierCurveRotorPockets.py
+++ b/examples/adaptive_library/BezierCurveRotorPockets.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #
@@ -122,21 +122,13 @@ mc.reset_adaptive_geometry()
 # %%
 # Set adaptive parameter if required
 # ----------------------------------
-# The ``set_default_parameter`` function is defined to check if a parameter exists. If not,
+# The ``set_adaptive_parameter_default`` function checks if a parameter exists. If not,
 # it creates the parameter with a default value.
-def set_default_parameter(parameter_name, default_value):
-    try:
-        mc.get_adaptive_parameter_value(parameter_name)
-    except pymotorcad.MotorCADError:
-        mc.set_adaptive_parameter_value(parameter_name, default_value)
-
-
-# %%
-# Use the ``set_default_parameter()`` function to set the required ``L1 Bezier Curve Projection``,
-# ``L1 Upper Convex`` and ``L1 Lower Concave`` parameters if undefined.
-set_default_parameter("L1 Bezier Curve Projection", 6)
-set_default_parameter("L1 Upper Convex", 0.5)
-set_default_parameter("L1 Lower Concave", -0.3)
+# Set the required ``L1 Bezier Curve Projection``, ``L1 Upper Convex`` and ``L1 Lower Concave``
+# parameters if undefined.
+mc.set_adaptive_parameter_default("L1 Bezier Curve Projection", 6)
+mc.set_adaptive_parameter_default("L1 Upper Convex", 0.5)
+mc.set_adaptive_parameter_default("L1 Lower Concave", -0.3)
 
 # %%
 # The adaptive parameters are used to define the curved rotor pocket geometry with a Bezier

--- a/examples/adaptive_library/OblongStatorDuct.py
+++ b/examples/adaptive_library/OblongStatorDuct.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #
@@ -93,18 +93,6 @@ mc.reset_adaptive_geometry()
 # %%
 # Define necessary functions
 # --------------------------
-# Set adaptive parameter if required
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# The ``set_default_parameter`` function is defined to check if a parameter exists. If not,
-# it creates the parameter with a default value.
-def set_default_parameter(parameter_name, default_value):
-    try:
-        mc.get_adaptive_parameter_value(parameter_name)
-    except pymotorcad.MotorCADError:
-        mc.set_adaptive_parameter_value(parameter_name, default_value)
-
-
-# %%
 # Check line distance from origin
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # The rectangle consists of two lines of length equal to the rectangle width.
@@ -192,9 +180,9 @@ def get_arc_radius_halfduct(entity_start, entity_end, height, Line_origin, Symm_
 # -----------------------------------
 # From Motor-CAD, get the adaptive parameters and their values.
 #
-# Use the ``set_default_parameter()`` method to set the required ``Duct Arc Height`` parameter
-# if undefined.
-set_default_parameter("Duct Arc Height", 0.7)
+# Use the ``set_adaptive_parameter_default()`` method to set the required ``Duct Arc Height``
+# parameter if undefined.
+mc.set_adaptive_parameter_default("Duct Arc Height", 0.7)
 
 
 # %%

--- a/examples/adaptive_library/RoundParallelSlotBttm.py
+++ b/examples/adaptive_library/RoundParallelSlotBttm.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #
@@ -81,27 +81,13 @@ mc.reset_adaptive_geometry()
 
 
 # %%
-# Define necessary functions
-# --------------------------
-# Set adaptive parameter if required
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# The ``set_default_parameter`` function is defined to check if a parameter exists. If not,
-# it creates the parameter with a default value.
-def set_default_parameter(parameter_name, default_value):
-    try:
-        mc.get_adaptive_parameter_value(parameter_name)
-    except pymotorcad.MotorCADError:
-        mc.set_adaptive_parameter_value(parameter_name, default_value)
-
-
-# %%
 # Get required parameters and objects
 # -----------------------------------
 # From Motor-CAD, get the adaptive parameters and their values.
 #
-# Use the ``set_default_parameter`` method to set the required ``Slot Bttm Corner Radius``
+# Use the ``set_adaptive_parameter_default`` method to set the required ``Slot Bttm Corner Radius``
 # parameter if undefined.
-set_default_parameter("Slot Bttm Corner Radius", 0.5)
+mc.set_adaptive_parameter_default("Slot Bttm Corner Radius", 0.5)
 
 # %%
 # Get the slot bottom corner radius adaptive parameter value.

--- a/examples/adaptive_library/TrapezoidalDuct.py
+++ b/examples/adaptive_library/TrapezoidalDuct.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #
@@ -86,18 +86,6 @@ mc.reset_adaptive_geometry()
 # %%
 # Define necessary functions
 # --------------------------
-# Set adaptive parameter if required
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# The ``set_default_parameter`` function is defined to check if a parameter exists. If not,
-# it creates the parameter with a default value.
-def set_default_parameter(parameter_name, default_value):
-    try:
-        mc.get_adaptive_parameter_value(parameter_name)
-    except pymotorcad.MotorCADError:
-        mc.set_adaptive_parameter_value(parameter_name, default_value)
-
-
-# %%
 # Check line distance from origin
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # The rectangle consists of two lines of length equal to the rectangle width.
@@ -129,9 +117,9 @@ def check_line_origin_distance(i, duct_region):
 # -----------------------------------
 # From Motor-CAD, get the adaptive parameters and their values.
 #
-# Use the ``set_default_parameter()`` method to set the required ``Trapezoid_base_ratio`` parameter
-# if undefined.
-set_default_parameter("Trapezoid_base_ratio", 0.7)
+# Use the ``set_adaptive_parameter_default()`` method to set the required ``Trapezoid_base_ratio``
+# parameter if undefined.
+mc.set_adaptive_parameter_default("Trapezoid_base_ratio", 0.7)
 
 # %%
 # Set required parameters for the trapezoid: ratio of top width / base width

--- a/src/ansys/motorcad/core/methods/adaptive_geometry.py
+++ b/src/ansys/motorcad/core/methods/adaptive_geometry.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #
@@ -24,7 +24,7 @@
 from warnings import warn
 
 from ansys.motorcad.core.geometry import Region, RegionMagnet
-from ansys.motorcad.core.rpc_client_core import is_running_in_internal_scripting
+from ansys.motorcad.core.rpc_client_core import MotorCADError, is_running_in_internal_scripting
 
 
 class _RpcMethodsAdaptiveGeometry:
@@ -63,6 +63,22 @@ class _RpcMethodsAdaptiveGeometry:
         method = "GetAdaptiveParameterValue"
         params = [name]
         return self.connection.send_and_receive(method, params)
+
+    def set_adaptive_parameter_default(self, name, value):
+        """Set default value for an adaptive parameter, if the parameter does not already exist.
+
+        Parameters
+        ----------
+        name : string
+            name of parameter.
+        value : float
+            value of parameter.
+        """
+        self.connection.ensure_version_at_least("2024.0")
+        try:
+            self.get_adaptive_parameter_value(name)
+        except MotorCADError:
+            self.set_adaptive_parameter_value(name, value)
 
     def get_region(self, name):
         """Get Motor-CAD geometry region.

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #
@@ -187,6 +187,14 @@ def test_get_adaptive_parameter_value_does_not_exist(mc):
         mc.get_adaptive_parameter_value("testing_parameter")
 
     assert "No adaptive parameter found with name" in str(e_info.value)
+
+
+def test_set_adaptive_parameter_default(mc):
+    mc.set_adaptive_parameter_default("testing_parameter_default", 100)
+    assert mc.get_adaptive_parameter_value("testing_parameter_default") == 100
+    # As parameter already exists, this should not change the value
+    mc.set_adaptive_parameter_default("testing_parameter_default", 200)
+    assert mc.get_adaptive_parameter_value("testing_parameter_default") == 100
 
 
 def test_get_region(mc):


### PR DESCRIPTION
In many of the adaptive template examples, we define a function that creates an adaptive template parameter with a default value, if the parameter does not already exist (otherwise the parameter is left unchanged). 

This PR adds a PyMotorCAD method to do this, to reduce duplicated code in the examples, and make this easier for users.