### PR TITLE
Remove numpy dependency for harmonic graph calculation

### DIFF
--- a/src/ansys/motorcad/core/methods/rpc_methods_graphs.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_graphs.py
@@ -42,14 +42,14 @@ def _dft_real(values):
 
     Parameters
     ----------
-    time_domain : list of real
+    values : list of real
         time domain data
 
     Returns
     -------
-    real_components : list
+    real : list
         Real components of the dft.
-    imaginary_components : list
+    imag : list
         Imaginary components of the dft.
     """
     length_in = len(values)

--- a/src/ansys/motorcad/core/methods/rpc_methods_graphs.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_graphs.py
@@ -285,10 +285,6 @@ class _RpcMethodsGraphs:
                 # Multiply by 2 to account for the positive and negative frequency component
                 y_fft_real[i] = 2 * y_fft_real[i]
                 y_fft_imag[i] = 2 * y_fft_imag[i]
-            else:
-                # 0th component does not need to be doubled
-                y_fft_real[i] = y_fft_real[i]
-                y_fft_imag[i] = y_fft_imag[i]
 
         # Get amplitude and angle:
         y_mag = []

--- a/src/ansys/motorcad/core/methods/rpc_methods_graphs.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_graphs.py
@@ -36,7 +36,7 @@ class Magnetic3dGraph:
     data: list
 
 
-def _dft_real(time_domain):
+def _dft_real(values):
     """
     Calculate a discrete fourier transform from a real valued list.
 
@@ -52,26 +52,18 @@ def _dft_real(time_domain):
     imaginary_components : list
         Imaginary components of the dft.
     """
-    real_components = []
-    imaginary_components = []
-    length_input = len(time_domain)
+    length_in = len(values)
     # Discard terms above Nyquist limit
-    length_output = length_input // 2 + 1
-    for i in range(length_output):
-        real_component = 0
-        imag_component = 0
-        for j in range(length_input):
-            real_component = (
-                real_component
-                + time_domain[j] * math.cos(i * j * 2 * math.pi / length_input) / length_input
-            )
-            imag_component = (
-                imag_component
-                - time_domain[j] * math.sin(i * j * 2 * math.pi / length_input) / length_input
-            )
-        real_components.append(real_component)
-        imaginary_components.append(imag_component)
-    return real_components, imaginary_components
+    length_out = length_in // 2 + 1
+
+    real = [0] * length_out
+    imag = [0] * length_out
+
+    for i in range(length_out):
+        for j in range(length_in):
+            real[i] = real[i] + values[j] * math.cos(i * j * 2 * math.pi / length_in) / length_in
+            imag[i] = imag[i] - values[j] * math.sin(i * j * 2 * math.pi / length_in) / length_in
+    return real, imag
 
 
 class _RpcMethodsGraphs:


### PR DESCRIPTION
Implements a trivial DFT for the harmonic graph calculation. For normal Motor-CAD graph lengths, the speed penalty compared to an FFT should not be significant.