### PR TITLE
Add version checking and backwards compatibility for file name check

### DIFF
--- a/src/ansys/motorcad/core/methods/rpc_methods_variables.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_variables.py
@@ -146,10 +146,21 @@ class _RpcMethodsVariables:
         str
             Current .mot file path and name
         """
-        self.connection.ensure_version_at_least("2025.0")
-        method = "GetMotorCADFileName"
-        if self.connection.send_and_receive(method) == "":
-            warn("No file has been loaded in this MotorCAD instance")
-            return None
+        if self.connection.check_version_at_least("2025.0"):
+            method = "GetMotorCADFileName"
+            if self.connection.send_and_receive(method) == "":
+                warn("No file has been loaded in this MotorCAD instance")
+                return None
+            else:
+                return self.connection.send_and_receive(method)
         else:
-            return self.connection.send_and_receive(method)
+            warn(
+                "GetMotorCADFileName not available in Motor-CAD "
+                + self.connection.program_version
+                + ". Returning value of CurrentMotFilePath_MotorLAB"
+            )
+            if self.get_variable("CurrentMotFilePath_MotorLAB") == "":
+                warn("No file has been loaded in this MotorCAD instance")
+                return None
+            else:
+                return self.get_variable("CurrentMotFilePath_MotorLAB")

--- a/src/ansys/motorcad/core/methods/rpc_methods_variables.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_variables.py
@@ -146,6 +146,7 @@ class _RpcMethodsVariables:
         str
             Current .mot file path and name
         """
+        self.connection.ensure_version_at_least("2025.0")
         method = "GetMotorCADFileName"
         if self.connection.send_and_receive(method) == "":
             warn("No file has been loaded in this MotorCAD instance")

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -143,3 +143,23 @@ def test_get_file_name():
     mc.save_to_file(file_path)
     assert mc.get_file_name() == file_path
     remove(file_path)
+
+
+def test_get_file_name_fallback():
+    mc = MotorCAD()
+    # Pretend to be an older version
+    mc.connection.program_version = "2024.2.3.1"
+
+    file_path = get_dir_path() + r"\test_files\temp_files\Get_File_Name.mot"
+
+    if path.exists(file_path):
+        remove(file_path)
+
+    assert path.exists(file_path) is False
+
+    with pytest.warns():
+        mc.get_file_name()
+
+    mc.save_to_file(file_path)
+    assert mc.get_file_name() == file_path
+    remove(file_path)


### PR DESCRIPTION
Fixes #461 

This checks the Motor-CAD version in get_file_name, as the underlying API call was only added to Motor-CAD 2025 R1. 

If the Motor-CAD version does not implement the API call, this falls back to returning the variable CurrentMotFilePath_MotorLAB which should match the Motor-CAD file name. This isn't necessary, but may be helpful for users running a newer PyMotorCAD than Motor-CAD.