### PR TITLE
Fix CWD when launching Motor-CAD

### DIFF
--- a/src/ansys/motorcad/core/rpc_client_core.py
+++ b/src/ansys/motorcad/core/rpc_client_core.py
@@ -22,6 +22,7 @@
 
 """Contains the JSON-RPC client for connecting to an instance of Motor-CAD."""
 from os import environ, path
+from pathlib import Path
 import re
 import socket
 import subprocess
@@ -413,7 +414,8 @@ class _MotorCADConnection:
             )
 
         motor_process = subprocess.Popen(
-            [self.__MotorExe, "/PORT=" + str(self._port), "/SCRIPTING"]
+            [self.__MotorExe, "/PORT=" + str(self._port), "/SCRIPTING"],
+            cwd=Path(self.__MotorExe).parent.absolute(),
         )
 
         pid = motor_process.pid


### PR DESCRIPTION
Fixes cwd of Motor-CAD being wrong when launching from automation. 

To replicate bug

1. Create a file with an external lab model file with a relative path:
![image](https://github.com/user-attachments/assets/a09d59b6-eb99-4648-b9b0-70b94b0a1af8)

2. Launch Motor-CAD using PyMotorCAD and load the file.
3. Reload model import - previously file cannot be found
![image](https://github.com/user-attachments/assets/281f48d7-6c56-4b07-b8c9-05b574afe555)

