### PR TITLE
Avoid warning about setting region type when creating with get_region

### DIFF
--- a/src/ansys/motorcad/core/geometry.py
+++ b/src/ansys/motorcad/core/geometry.py
@@ -254,10 +254,12 @@ class Region(object):
             new_region._magnet_polarity = json["magnet_polarity"]
             new_region._br_magnet = json["magnet_br_value"]
         else:
-            new_region = cls(motorcad_instance)
-
-        if has_region_type:
-            new_region._region_type = RegionType(json["region_type"])
+            if has_region_type:
+                new_region = cls(
+                    motorcad_instance=motorcad_instance, region_type=RegionType(json["region_type"])
+                )
+            else:
+                new_region = cls(motorcad_instance=motorcad_instance)
 
         # self.Entities = json.Entities
         new_region._name = json["name"]

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -214,7 +214,7 @@ def test_get_region_dxf(mc):
     mc.load_dxf_file(get_dir_path() + r"\test_files\dxf_import.dxf")
     expected_region = geometry.Region(region_type=RegionType.dxf_import)
     expected_region.name = "DXFRegion_Rotor"
-    expected_region.colour = (0, 0, 0)
+    expected_region.colour = (192, 192, 192)
     expected_region.duplications = 8
     expected_region.add_entity(
         geometry.Arc(

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -214,7 +214,7 @@ def test_get_region_dxf(mc):
     mc.load_dxf_file(get_dir_path() + r"\test_files\dxf_import.dxf")
     expected_region = geometry.Region(region_type=RegionType.dxf_import)
     expected_region.name = "DXFRegion_Rotor"
-    expected_region.colour = (192, 192, 192)
+    expected_region.colour = (0, 0, 0)
     expected_region.duplications = 8
     expected_region.add_entity(
         geometry.Arc(


### PR DESCRIPTION
get_region() calls Region._from_json. Following #477 this was generating a warning, because we were setting the region type after the region was created. This PR avoids this warning being raised.