### PR TITLE
Remove colour check in region equality.

### DIFF
--- a/src/ansys/motorcad/core/geometry.py
+++ b/src/ansys/motorcad/core/geometry.py
@@ -142,7 +142,6 @@ class Region(object):
         return (
             isinstance(other, Region)
             and self._name == other._name
-            and self._colour == other._colour
             # and self.area == other.area ->
             # Already check entities - can't expect user to calculate area
             # and self.centroid == other.centroid ->


### PR DESCRIPTION
Overkill and regression tests break if dxf regions change order in tree