### PR TITLE
Add ability to set default Motor-CAD exe from environment variable

### DIFF
--- a/src/ansys/motorcad/core/rpc_client_core.py
+++ b/src/ansys/motorcad/core/rpc_client_core.py
@@ -54,6 +54,12 @@ _METHOD_SUCCESS = 0
 
 MOTORCAD_EXE_GLOBAL = ""
 
+if MOTORCAD_EXE_GLOBAL == "":
+    if "PYMOTORCAD_EXE" in environ:
+        pymotorcad_exe_environment_variable = environ["PYMOTORCAD_EXE"]
+        if pymotorcad_exe_environment_variable != "":
+            MOTORCAD_EXE_GLOBAL = pymotorcad_exe_environment_variable
+
 MOTORCAD_PROC_NAMES = ["MotorCAD", "Motor-CAD"]
 
 # Useful for debugging new functions when using debug Motor-CAD


### PR DESCRIPTION
Needed for https://github.com/ansys-internal/motor-cad/pull/2290

Needs review by @matthewAnsys 

This might also be useful for running tests on different version of Motor-CAD.

Not bothered about code coverage for this as it will be extensively used by Motor-CAD regression testing