### PR TITLE
Allow FEA mesh control around high curvature regions by dividing arcs

### DIFF
--- a/src/ansys/motorcad/core/geometry.py
+++ b/src/ansys/motorcad/core/geometry.py
@@ -24,7 +24,7 @@
 from cmath import polar, rect
 from copy import deepcopy
 from enum import Enum
-from math import atan2, cos, degrees, inf, isclose, radians, sin, sqrt
+from math import acos, atan2, cos, degrees, fabs, floor, inf, isclose, radians, sin, sqrt
 import warnings
 from warnings import warn
 
@@ -880,6 +880,55 @@ class Region(object):
         """
         for corner in corner_coordinates:
             self.round_corner(corner, radius)
+
+    def limit_arc_chord(self, max_chord_height):
+        """Limit the chord height for arcs in a region.
+
+        Subdivide arcs if required to ensure the arc's chord height (the distance between the arc
+        midpoint and the midpoint of a line between the start and end) is lower than the specified
+        value. This can be used to force a fine FEA mesh around entities with high curvature.
+
+        Parameters:
+            max_chord_height: float
+                The maximum chord height allowed.
+        """
+        new_entity_list = []
+        for entity in self.entities:
+            if (
+                isinstance(entity, Arc)
+                and (entity.radius != 0)
+                and (fabs(entity.radius * 2) > max_chord_height)
+            ):
+                # Find maximum arc angle so the chord height is equal to the required maximum error
+                max_angle = degrees(2 * acos(1 - max_chord_height / fabs(entity.radius)))
+
+                # Find how many segments are needed to achieve this
+                if max_angle > 0:
+                    segmentation = floor(entity.total_angle / max_angle)
+                else:
+                    segmentation = 1
+
+                # If required, split the arc into segments
+                if segmentation > 1:
+                    segment_start = entity.start
+                    for segment in range(1, segmentation + 1):
+                        segment_end = entity.get_coordinate_from_distance(
+                            entity.start, fraction=segment / segmentation
+                        )
+                        new_arc = Arc(segment_start, segment_end, entity.centre, entity.radius)
+                        # Add to the list
+                        new_entity_list.append(new_arc)
+                        # Ready for next segment
+                        segment_start = segment_end
+                else:
+                    # Arc already OK, just add to list as-is
+                    new_entity_list.append(entity)
+            else:
+                # Add to list unchanged
+                new_entity_list.append(entity)
+
+        # Update the entity list
+        self.entities = new_entity_list
 
     def find_entity_from_coordinates(self, coordinate_1, coordinate_2):
         """Search through region to find an entity with start and end coordinates.

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1747,13 +1747,17 @@ def test_limit_arc_chord():
     # and check we have the right number of entities
     square_1 = square(20, 0, 0)
     square_2 = square(20, 0, 0)
+    square_3 = square(20, 0, 0)
     assert len(square_1.entities) == 4
     assert len(square_2.entities) == 4
+    assert len(square_3.entities) == 4
     corner_radius = 5
     square_1.round_corners(square_1.points, corner_radius)
     square_2.round_corners(square_2.points, corner_radius)
+    square_3.round_corners(square_3.points, corner_radius)
     assert len(square_1.entities) == 8
     assert len(square_2.entities) == 8
+    assert len(square_3.entities) == 8
 
     # This should split the corners into three
     chord_tolerance = 0.1
@@ -1764,6 +1768,11 @@ def test_limit_arc_chord():
     chord_tolerance = 8
     square_2.limit_arc_chord(chord_tolerance)
     assert len(square_2.entities) == 8
+
+    # This should not split the corners (invalid input)
+    chord_tolerance = 0
+    square_3.limit_arc_chord(chord_tolerance)
+    assert len(square_3.entities) == 8
 
 
 def test_subtract_regions(mc):

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -42,7 +42,7 @@ from ansys.motorcad.core.geometry import (
     _orientation_of_three_points,
     rt_to_xy,
 )
-from ansys.motorcad.core.geometry_shapes import eq_triangle_h, triangular_notch
+from ansys.motorcad.core.geometry_shapes import eq_triangle_h, square, triangular_notch
 import ansys.motorcad.core.rpc_client_core as rpc_client_core
 from ansys.motorcad.core.rpc_client_core import DEFAULT_INSTANCE, set_default_instance
 
@@ -1740,6 +1740,30 @@ def test_do_not_round_corner():
     assert triangle_3.entities[2].end == triangle_2.entities[2].midpoint
     assert triangle_3.entities[3].start == triangle_2.entities[2].midpoint
     assert triangle_3.entities[3].end == triangle_2.entities[2].end
+
+
+def test_limit_arc_chord():
+    # Draw a square, round its corners, and then limit the radii,
+    # and check we have the right number of entities
+    square_1 = square(20, 0, 0)
+    square_2 = square(20, 0, 0)
+    assert len(square_1.entities) == 4
+    assert len(square_2.entities) == 4
+    corner_radius = 5
+    square_1.round_corners(square_1.points, corner_radius)
+    square_2.round_corners(square_2.points, corner_radius)
+    assert len(square_1.entities) == 8
+    assert len(square_2.entities) == 8
+
+    # This should split the corners into three
+    chord_tolerance = 0.1
+    square_1.limit_arc_chord(chord_tolerance)
+    assert len(square_1.entities) == 16
+
+    # This should not split the corners
+    chord_tolerance = 8
+    square_2.limit_arc_chord(chord_tolerance)
+    assert len(square_2.entities) == 8
 
 
 def test_subtract_regions(mc):


### PR DESCRIPTION
For regions with high curvature, the standard FEA mesh density approach does not take into account that higher mesh density is required to capture the curvature. This allows users to split the arcs in a region, to force a finer FEA mesh (as we will always have at least one mesh element per arc).