### PR TITLE
Fixed incorrect RegionType enums

### DIFF
--- a/examples/adaptive_library/RoundParallelSlotBttm.py
+++ b/examples/adaptive_library/RoundParallelSlotBttm.py
@@ -99,7 +99,6 @@ radius = mc.get_adaptive_parameter_value("Slot Bttm Corner Radius")
 stator = mc.get_region("Stator")
 winding_1 = mc.get_region("ArmatureSlotL1")
 winding_2 = mc.get_region("ArmatureSlotR1")
-stator_slot = mc.get_region("StatorSlot")
 liner = mc.get_region("Liner")
 impreg = mc.get_region("Impreg")
 
@@ -122,7 +121,6 @@ draw_objects_debug([stator, impreg, impreg_corners[0], impreg_corners[1]])
 # ``Region.round_corners`` method. Armature winding regions only have 1 of the two corners, so use
 # the ``Region.round_corner`` method for these regions.
 stator.round_corners(corners, radius)
-stator_slot.round_corners(corners, radius)
 liner.round_corners(corners, radius)
 winding_1.round_corner(corners[1], radius)
 winding_2.round_corner(corners[0], radius)
@@ -136,7 +134,6 @@ impreg.round_corners(impreg_corners, radius)
 # %%
 # Set the edited regions in Motor-CAD.
 mc.set_region(stator)
-mc.set_region(stator_slot)
 mc.set_region(winding_1)
 mc.set_region(winding_2)
 mc.set_region(liner)

--- a/src/ansys/motorcad/core/geometry.py
+++ b/src/ansys/motorcad/core/geometry.py
@@ -36,8 +36,8 @@ class RegionType(Enum):
 
     stator = "Stator"
     rotor = "Rotor"
-    slot_area_stator = "Stator Slot"
-    slot_area_rotor = "Rotor Slot"
+    slot_area_stator = "Stator Slot Area"
+    slot_area_rotor = "Rotor Slot Area"
     slot_split = "Split Slot"
     stator_liner = "Stator Liner"
     rotor_liner = "Rotor Liner"


### PR DESCRIPTION
Updated several enum types in the RegionType Class, which previously did not match with their corresponding strings in Motor-CAD and resulted in errors when users attempted to get said regions.