### PR TITLE
Add more information to save_fea_data documentation, and move deprecation warnings so they render correctly.

### DIFF
--- a/src/ansys/motorcad/core/methods/rpc_methods_fea_geometry.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_fea_geometry.py
@@ -194,7 +194,28 @@ class _RpcMethodsFEAGeometry:
         return self.connection.send_and_receive(method, params)
 
     def save_fea_data(self, file, first_step, final_step, outputs, regions, separator):
-        """Save raw data for the open FEA solution."""
+        """Save raw data for the current FEA solution.
+
+        Parameters
+        ----------
+        file : str
+            File location to write to.
+        first_step : int
+            First step of results required (for transient calculation).
+        final_step : int
+            Final step of results required (for transient calculation).
+        outputs : float
+            FEA data requested, for example RegCode, B, Pt, B*BremX (mathematical expressions
+            can be handled). Multiple outputs be passed as a comma-separated string, for example
+            'RegCode,B,Pt,B*BremX'.
+        regions : str
+            FEA region names that data is wanted for, for example L1_1Magnet1N1, Rotor,
+            ArmatureSlotR2. Multiple regions must be passed as a comma-separated string,
+            for example 'L1_1Magnet1N1,Rotor,ArmatureSlotR2'.
+            An empty string will include all FEA regions.
+        separator : str
+            Separator used in writing the output file.
+        """
         method = "SaveFEAData"
         params = [file, first_step, final_step, outputs, regions, separator]
         return self.connection.send_and_receive(method, params)
@@ -223,6 +244,10 @@ class _RpcMethodsFEAGeometry:
     def edit_magnet_region(self, region_name, magnet_material, br_angle, br_multiplier):
         """Edit a magnet region.
 
+        .. deprecated:: 0.6.0
+          `edit_magnet_region` will be removed with Motor-CAD 2025R2 (tentative).
+          Functionality replaced by adaptive templates.
+
         Parameters
         ----------
         region_name : str
@@ -233,10 +258,6 @@ class _RpcMethodsFEAGeometry:
             Br angle of the magnet.
         br_multiplier : float
             Br multiplier for the magnet.
-
-        .. deprecated:: 0.6.0
-          `edit_magnet_region` will be removed with Motor-CAD 2025R2 (tentative).
-          Functionality replaced by adaptive templates.
         """
         geometry_deprecation_warning("edit_magnet_region")
         method = "EditMagnetRegion"
@@ -246,6 +267,10 @@ class _RpcMethodsFEAGeometry:
     def delete_regions(self, region_name):
         """Delete a comma-separated list of named regions or all regions.
 
+        .. deprecated:: 0.6.0
+          `delete_regions` will be removed with Motor-CAD 2025R2 (tentative).
+          Functionality replaced by adaptive templates.
+
         Parameters
         ----------
         region_name: list
@@ -253,10 +278,6 @@ class _RpcMethodsFEAGeometry:
            all regions are deleted. If the name of a region to delete contains
            a space, enclose the name in double quotation marks. For example,
            ``"Rotor Pocket"``.
-
-        .. deprecated:: 0.6.0
-          `delete_regions` will be removed with Motor-CAD 2025R2 (tentative).
-          Functionality replaced by adaptive templates.
         """
         geometry_deprecation_warning("delete_regions")
         method = "DeleteRegions"
@@ -315,6 +336,10 @@ class _RpcMethodsFEAGeometry:
     def add_line_xy(self, x_start, y_start, x_end, y_end):
         """Add a line to the Motor-CAD axial geometry with an x, y coordinate system.
 
+        .. deprecated:: 0.6.0
+          `add_line_xy` will be removed with Motor-CAD 2025R2 (tentative).
+          Functionality replaced by adaptive templates.
+
         Parameters
         ----------
         x_start : float
@@ -325,10 +350,6 @@ class _RpcMethodsFEAGeometry:
             End position for the x coordinate.
         y_end : float
             End position for the y coordinate.
-
-        .. deprecated:: 0.6.0
-          `add_line_xy` will be removed with Motor-CAD 2025R2 (tentative).
-          Functionality replaced by adaptive templates.
         """
         geometry_deprecation_warning("add_line_xy")
         method = "AddLine_XY"
@@ -340,6 +361,10 @@ class _RpcMethodsFEAGeometry:
 
         Use degrees for angles.
 
+        .. deprecated:: 0.6.0
+          `add_line_rt` will be removed with Motor-CAD 2025R2 (tentative).
+          Functionality replaced by adaptive templates.
+
         Parameters
         ----------
         radius_start : float
@@ -350,10 +375,6 @@ class _RpcMethodsFEAGeometry:
             End position for the radial coordinate.
         theta_end : float
             End position for the angular coordinate in degrees.
-
-        .. deprecated:: 0.6.0
-          `add_line_rt` will be removed with Motor-CAD 2025R2 (tentative).
-          Functionality replaced by adaptive templates.
         """
         geometry_deprecation_warning("add_line_rt")
         method = "AddLine_RT"
@@ -364,6 +385,10 @@ class _RpcMethodsFEAGeometry:
         """Add an arc to the Motor-CAD axial geometry with an x, y coordinate system.
 
         This method uses the center point, radius, and angles. Use degrees for angles.
+
+        .. deprecated:: 0.6.0
+          `add_arc_xy` will be removed with Motor-CAD 2025R2 (tentative).
+          Functionality replaced by adaptive templates.
 
         Parameters
         ----------
@@ -377,10 +402,6 @@ class _RpcMethodsFEAGeometry:
             Angular coordinate of the arc end point in degrees.
         radius : float
             Radius of the arc from the center point.
-
-        .. deprecated:: 0.6.0
-          `add_arc_xy` will be removed with Motor-CAD 2025R2 (tentative).
-          Functionality replaced by adaptive templates.
         """
         geometry_deprecation_warning("add_arc_xy")
         method = "AddArc_XY"
@@ -391,6 +412,10 @@ class _RpcMethodsFEAGeometry:
         """Add an arc to the Motor-CAD axial geometry with an r, t (polar) coordinate system.
 
         This method uses the center point, radius, and angles. Use degrees for angles.
+
+        .. deprecated:: 0.6.0
+          `add_arc_rt` will be removed with Motor-CAD 2025R2 (tentative).
+          Functionality replaced by adaptive templates.
 
         Parameters
         ----------
@@ -404,10 +429,6 @@ class _RpcMethodsFEAGeometry:
             Angular coordinate of the arc end point in degrees.
         radius : float
             Radius of the arc from the center point.
-
-        .. deprecated:: 0.6.0
-          `add_arc_rt` will be removed with Motor-CAD 2025R2 (tentative).
-          Functionality replaced by adaptive templates.
         """
         geometry_deprecation_warning("add_arc_rt")
         method = "AddArc_RT"
@@ -418,6 +439,10 @@ class _RpcMethodsFEAGeometry:
         """Add an arc to the Motor-CAD axial geometry with an r, t (polar) coordinate system.
 
         This method uses start, end, and center coordinates. Use degrees for angles.
+
+        .. deprecated:: 0.6.0
+          `add_arc_centre_start_end_xy` will be removed with Motor-CAD 2025R2 (tentative).
+          Functionality replaced by adaptive templates.
 
         Parameters
         ----------
@@ -433,10 +458,6 @@ class _RpcMethodsFEAGeometry:
             End position for the x coordinate.
         y_end : float
             End position for the y coordinate.
-
-        .. deprecated:: 0.6.0
-          `add_arc_centre_start_end_xy` will be removed with Motor-CAD 2025R2 (tentative).
-          Functionality replaced by adaptive templates.
         """
         geometry_deprecation_warning("add_arc_centre_start_end_xy")
         method = "AddArc_CentreStartEnd_XY"
@@ -449,6 +470,10 @@ class _RpcMethodsFEAGeometry:
         """Add an arc to the Motor-CAD axial geometry with an r, t (polar) coordinate system.
 
         This method uses start, end, and center coordinates. Use degrees for angles.
+
+        .. deprecated:: 0.6.0
+          `add_arc_centre_start_end_rt` will be removed with Motor-CAD 2025R2 (tentative).
+          Functionality replaced by adaptive templates.
 
         Parameters
         ----------
@@ -464,10 +489,6 @@ class _RpcMethodsFEAGeometry:
             end position radial coordinate
         theta_end : float
             End position for the angular coordinate in degrees.
-
-        .. deprecated:: 0.6.0
-          `add_arc_centre_start_end_rt` will be removed with Motor-CAD 2025R2 (tentative).
-          Functionality replaced by adaptive templates.
         """
         geometry_deprecation_warning("add_arc_centre_start_end_rt")
         method = "AddArc_CentreStartEnd_RT"
@@ -479,6 +500,10 @@ class _RpcMethodsFEAGeometry:
 
         If a region already exists, this method overwrites the existing region.
 
+        .. deprecated:: 0.6.0
+          `add_region_xy` will be removed with Motor-CAD 2025R2 (tentative).
+          Functionality replaced by adaptive templates.
+
         Parameters
         ----------
         x : float
@@ -487,10 +512,6 @@ class _RpcMethodsFEAGeometry:
             Region position for the y coordinate.
         region_name : string
             Name of the region.
-
-        .. deprecated:: 0.6.0
-          `add_region_xy` will be removed with Motor-CAD 2025R2 (tentative).
-          Functionality replaced by adaptive templates.
         """
         geometry_deprecation_warning("add_region_xy")
         method = "AddRegion_XY"
@@ -504,6 +525,10 @@ class _RpcMethodsFEAGeometry:
 
         Use degrees for angles.
 
+        .. deprecated:: 0.6.0
+          `add_region_rt` will be removed with Motor-CAD 2025R2 (tentative).
+          Functionality replaced by adaptive templates.
+
         Parameters
         ----------
         radius : float
@@ -512,10 +537,6 @@ class _RpcMethodsFEAGeometry:
             Region position for the angular coordinate in degrees.
         region_name : string
             Name of the region.
-
-        .. deprecated:: 0.6.0
-          `add_region_rt` will be removed with Motor-CAD 2025R2 (tentative).
-          Functionality replaced by adaptive templates.
         """
         geometry_deprecation_warning("add_region_rt")
         method = "AddRegion_RT"
@@ -531,6 +552,10 @@ class _RpcMethodsFEAGeometry:
 
         Use degrees for angles.
 
+        .. deprecated:: 0.6.0
+          `add_magnet_region_xy` will be removed with Motor-CAD 2025R2 (tentative).
+          Functionality replaced by adaptive templates.
+
         Parameters
         ----------
         x : float
@@ -547,10 +572,6 @@ class _RpcMethodsFEAGeometry:
             Magnet Br multiplier. The default is ``1``.
         polarity_code : integer
             Magnet polarity, where ``0`` is north and ``1`` is south.
-
-        .. deprecated:: 0.6.0
-          `add_magnet_region_xy` will be removed with Motor-CAD 2025R2 (tentative).
-          Functionality replaced by adaptive templates.
         """
         geometry_deprecation_warning("add_magnet_region_xy")
         method = "AddMagnetRegion_XY"
@@ -565,6 +586,10 @@ class _RpcMethodsFEAGeometry:
         If a region already exists, this method overwrites the existing region.
 
         Use degrees for angles.
+
+        .. deprecated:: 0.6.0
+          `add_magnet_region_rt` will be removed with Motor-CAD 2025R2 (tentative).
+          Functionality replaced by adaptive templates.
 
         Parameters
         ----------
@@ -582,10 +607,6 @@ class _RpcMethodsFEAGeometry:
             Magnet Br multiplier. The default is ``1``.
         polarity_code : integer
             Magnet polarity, where ``0`` is north and ``1`` is south.
-
-        .. deprecated:: 0.6.0
-          `add_magnet_region_rt` will be removed with Motor-CAD 2025R2 (tentative).
-          Functionality replaced by adaptive templates.
         """
         geometry_deprecation_warning("add_magnet_region_rt")
         method = "AddMagnetRegion_RT"
@@ -616,6 +637,10 @@ class _RpcMethodsFEAGeometry:
         .. note::
            Do not use this method to add a magnet. Use the ``add_magnet_region_xy`` method.
 
+        .. deprecated:: 0.6.0
+          `add_point_custom_material_xy` will be removed with Motor-CAD 2025R2 (tentative).
+          Functionality replaced by adaptive templates.
+
         Parameters
         ----------
         x : float
@@ -632,10 +657,6 @@ class _RpcMethodsFEAGeometry:
             VCL color. For more information, see https://wiki.freepascal.org/Colors.
             The color can be designaed as a hexadecimal value, such as ``"$008000"``
             or a color name such as ``"clGreen"``.
-
-        .. deprecated:: 0.6.0
-          `add_point_custom_material_xy` will be removed with Motor-CAD 2025R2 (tentative).
-          Functionality replaced by adaptive templates.
         """
         geometry_deprecation_warning("add_point_custom_material_xy")
         method = "AddPoint_CustomMaterial_XY"
@@ -649,6 +670,10 @@ class _RpcMethodsFEAGeometry:
            Do not use this method to add a magnet. Use the ``add_magnet_region_rt`` method.
 
         Use degrees for angles.
+
+        .. deprecated:: 0.6.0
+          `add_point_custom_material_rt` will be removed with Motor-CAD 2025R2 (tentative).
+          Functionality replaced by adaptive templates.
 
         Parameters
         ----------
@@ -666,10 +691,6 @@ class _RpcMethodsFEAGeometry:
             VCL color. For more information, see https://wiki.freepascal.org/Colors.
             The color can be designaed as a hexadecimal value, such as ``"$008000"``
             or a color name such as ``"clGreen"``.
-
-        .. deprecated:: 0.6.0
-          `add_point_custom_material_rt` will be removed with Motor-CAD 2025R2 (tentative).
-          Functionality replaced by adaptive templates.
         """
         geometry_deprecation_warning("add_point_custom_material_rt")
         method = "AddPoint_CustomMaterial_RT"

--- a/src/ansys/motorcad/core/methods/rpc_methods_fea_geometry.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_fea_geometry.py
@@ -204,7 +204,7 @@ class _RpcMethodsFEAGeometry:
             First step of results required (for transient calculation).
         final_step : int
             Final step of results required (for transient calculation).
-        outputs : float
+        outputs : str
             FEA data requested, for example RegCode, B, Pt, B*BremX (mathematical expressions
             can be handled). Multiple outputs be passed as a comma-separated string, for example
             'RegCode,B,Pt,B*BremX'.

--- a/src/ansys/motorcad/core/methods/rpc_methods_fea_geometry.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_fea_geometry.py
@@ -205,9 +205,8 @@ class _RpcMethodsFEAGeometry:
         final_step : int
             Final step of results required (for transient calculation).
         outputs : str
-            FEA data requested, for example RegCode, B, Pt, B*BremX (mathematical expressions
-            can be handled). Multiple outputs be passed as a comma-separated string, for example
-            'RegCode,B,Pt,B*BremX'.
+            FEA data requested, for example RegCode, B, Pt. Multiple outputs be passed as a
+            comma-separated string, for example 'RegCode,B,Pt'.
         regions : str
             FEA region names that data is wanted for, for example L1_1Magnet1N1, Rotor,
             ArmatureSlotR2. Multiple regions must be passed as a comma-separated string,


### PR DESCRIPTION
The save_fea_data documentation wasn't very informative, so I have updated this to include a description of the parameters. Additionally, the depreciation warnings for some functions were incorrectly appearing as part of the parameter list, so these have been moved to render correctly.