### PR TITLE
Fix Incorrect EntityList equality evaluation

### DIFF
--- a/src/ansys/motorcad/core/geometry.py
+++ b/src/ansys/motorcad/core/geometry.py
@@ -2083,6 +2083,10 @@ class EntityList(list):
         """Compare equality of 2 EntityList objects."""
         return self._entities_same(other, check_reverse=True)
 
+    def __ne__(self, other):
+        """Compare difference of 2 EntityList objects."""
+        return not self == other
+
     def reverse(self):
         """Reverse EntityList, including entity start end coordinates."""
         super().reverse()

--- a/src/ansys/motorcad/core/geometry.py
+++ b/src/ansys/motorcad/core/geometry.py
@@ -2139,6 +2139,9 @@ class EntityList(list):
             else:
                 return False
 
+        if len(self) != len(entities_to_compare):
+            return False
+
         if check_reverse:
             if _entities_same_with_direction(self, entities_to_compare):
                 return True

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -510,11 +510,12 @@ def test_reverse_arc():
 
 
 def test_entities_same_subset():
-    entities = geometry.EntityList(
-        [Line(Coordinate(0, 0), Coordinate(0, 1)), Line(Coordinate(0, 1), Coordinate(1, 0))]
-    )
-    entities_expected = geometry.EntityList([Line(Coordinate(0, 0), Coordinate(0, 1))])
-    assert entities != entities_expected
+    arc1 = Arc(Coordinate(1, 0), Coordinate(0, 1), radius=1)
+    arc2 = Arc(Coordinate(0, 1), Coordinate(-1, 0), radius=1)
+    ent1 = geometry.EntityList([arc1, arc2])
+    ent2 = geometry.EntityList([arc1])
+
+    assert ent1 != ent2
 
 
 def test_entities_same():

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -509,6 +509,14 @@ def test_reverse_arc():
     assert arc == expected_line
 
 
+def test_entities_same_subset():
+    entities = geometry.EntityList(
+        [Line(Coordinate(0, 0), Coordinate(0, 1)), Line(Coordinate(0, 1), Coordinate(1, 0))]
+    )
+    entities_expected = geometry.EntityList([Line(Coordinate(0, 0), Coordinate(0, 1))])
+    assert entities != entities_expected
+
+
 def test_entities_same():
     region = generate_constant_region()
     region_expected = generate_constant_region()


### PR DESCRIPTION
EntityList equality evaluation was previously evaluating whether the first list was a subset of the second. The new behaviour is as expected.