### PR TITLE
Update ci_cd.yml to run on Python 3.12

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
     steps:
       - name: Build wheelhouse and perform smoke test
         uses: ansys/actions/build-wheelhouse@v8

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11'] 
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
       - name: Build wheelhouse and perform smoke test
         uses: ansys/actions/build-wheelhouse@v8
@@ -77,7 +77,9 @@ jobs:
           
       - name: Test with tox
         # Only the tox environment specified in the tox.ini gh-actions is run
-        run: tox -e py310-coverage  
+        run: tox
+        env:
+          python-version: "3.12-cov-only"
         
       - uses: codecov/codecov-action@v4
         name: 'Upload coverage to Codecov'

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -77,9 +77,7 @@ jobs:
           
       - name: Test with tox
         # Only the tox environment specified in the tox.ini gh-actions is run
-        run: tox
-        env:
-          python: "py${{ env.MAIN_PYTHON_VERSION }}-cov-only"
+        run: tox -e py312-coverage
         
       - uses: codecov/codecov-action@v4
         name: 'Upload coverage to Codecov'

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -79,7 +79,7 @@ jobs:
         # Only the tox environment specified in the tox.ini gh-actions is run
         run: tox
         env:
-          python-version: "${{ env.MAIN_PYTHON_VERSION }}-cov-only"
+          python: "py${{ env.MAIN_PYTHON_VERSION }}-cov-only"
         
       - uses: codecov/codecov-action@v4
         name: 'Upload coverage to Codecov'

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 env:
-  MAIN_PYTHON_VERSION: '3.10'
+  MAIN_PYTHON_VERSION: '3.11'
   LIBRARY_NAME: ansys-motorcad-core
   LIBRARY_NAMESPACE: 'ansys.motorcad.core'
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 env:
-  MAIN_PYTHON_VERSION: '3.11'
+  MAIN_PYTHON_VERSION: '3.12'
   LIBRARY_NAME: ansys-motorcad-core
   LIBRARY_NAMESPACE: 'ansys.motorcad.core'
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -79,7 +79,7 @@ jobs:
         # Only the tox environment specified in the tox.ini gh-actions is run
         run: tox
         env:
-          python-version: "3.12-cov-only"
+          python-version: "${{ env.MAIN_PYTHON_VERSION }}-cov-only"
         
       - uses: codecov/codecov-action@v4
         name: 'Upload coverage to Codecov'

--- a/.github/workflows/nightly-motorcad-check.yml
+++ b/.github/workflows/nightly-motorcad-check.yml
@@ -38,4 +38,4 @@ jobs:
           python -m pip install --upgrade pip tox tox-gh-actions
           
       - name: Test with tox
-        run: tox -e py310-coverage  
+        run: tox -e py311-coverage  

--- a/.github/workflows/nightly-motorcad-check.yml
+++ b/.github/workflows/nightly-motorcad-check.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
       fail-fast: false
 
     steps:

--- a/.github/workflows/nightly-motorcad-check.yml
+++ b/.github/workflows/nightly-motorcad-check.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
       fail-fast: false
 

--- a/.github/workflows/nightly-motorcad-check.yml
+++ b/.github/workflows/nightly-motorcad-check.yml
@@ -22,7 +22,8 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+
       fail-fast: false
 
     steps:
@@ -38,4 +39,4 @@ jobs:
           python -m pip install --upgrade pip tox tox-gh-actions
           
       - name: Test with tox
-        run: tox -e py311-coverage  
+        run: tox

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
   - id: isort
 
 - repo: https://github.com/PyCQA/flake8
-  rev: 6.0.0
+  rev: 6.1.0
   hooks:
   - id: flake8
 

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -25,7 +25,7 @@ Installation
 
 Python module
 --------------
-The ``ansys.motorcad.core`` package currently supports Python 3.7 through Python 3.12 on Windows.
+The ``ansys.motorcad.core`` package currently supports Python 3.8 through Python 3.12 on Windows.
 
 Install the latest release from
 `PyPi <https://pypi.org/project/ansys-motorcad-core/>`_ with:

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -25,7 +25,7 @@ Installation
 
 Python module
 --------------
-The ``ansys.motorcad.core`` package currently supports Python 3.7 through Python 3.10 on Windows.
+The ``ansys.motorcad.core`` package currently supports Python 3.7 through Python 3.11 on Windows.
 
 Install the latest release from
 `PyPi <https://pypi.org/project/ansys-motorcad-core/>`_ with:

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -25,7 +25,7 @@ Installation
 
 Python module
 --------------
-The ``ansys.motorcad.core`` package currently supports Python 3.8 through Python 3.12 on Windows.
+The ``ansys.motorcad.core`` package currently supports Python 3.9 through Python 3.12 on Windows.
 
 Install the latest release from
 `PyPi <https://pypi.org/project/ansys-motorcad-core/>`_ with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
     "License :: OSI Approved :: MIT License",
     "Operating System :: Microsoft :: Windows",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
     "psutil >= 5.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
     "License :: OSI Approved :: MIT License",
     "Operating System :: Microsoft :: Windows",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ doc = [
     "numpydoc==1.8.0",
     "ansys-sphinx-theme==1.2.7",
     "sphinx-copybutton==0.5.2",
-    "sphinx-gallery==0.18.0",
+    "sphinx-gallery==0.19.0",
     "matplotlib",
     "scipy",
     "pypandoc==1.14",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+	"Programming Language :: Python :: 3.11",
 ]
 dependencies = [
     "psutil >= 5.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
-	"Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
     "psutil >= 5.9.0",

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ python =
     3.10: style,py310-coverage,doc
     3.11: style,py311-coverage,doc
     3.12: style,py312-coverage,doc
-    3.12-cov-only: py312-coverage
+    py3.12-cov-only: py312-coverage
 
 [testenv]
 description = Checks for project unit tests and coverage (if desired)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 description = Default tox environments list
 envlist =
-    style,{py38,py39,py310,py311,py312}{,-coverage},doc
+    style,{py39,py310,py311,py312}{,-coverage},doc
 skip_missing_interpreters = true
 isolated_build = true
 isolated_build_env = build
@@ -9,7 +9,6 @@ isolated_build_env = build
 [gh-actions]
 description = The tox environment to be executed in gh-actions for a given python version
 python =
-    3.8: style,py38-coverage,doc
     3.9: style,py39-coverage,doc
     3.10: style,py310-coverage,doc
     3.11: style,py311-coverage,doc
@@ -18,7 +17,6 @@ python =
 [testenv]
 description = Checks for project unit tests and coverage (if desired)
 basepython =
-    py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 description = Default tox environments list
 envlist =
-    style,{py37,py38,py39,py310,py311}{,-coverage},doc
+    style,{py38,py39,py310,py311,py12}{,-coverage},doc
 skip_missing_interpreters = true
 isolated_build = true
 isolated_build_env = build
@@ -9,20 +9,21 @@ isolated_build_env = build
 [gh-actions]
 description = The tox environment to be executed in gh-actions for a given python version
 python =
-    3.7: style,py37-coverage,doc
     3.8: style,py38-coverage,doc
     3.9: style,py39-coverage,doc
     3.10: style,py310-coverage,doc
     3.11: style,py311-coverage,doc
+    3.12: style,py312-coverage,doc
+    3.12-cov-only: py312-coverage
 
 [testenv]
 description = Checks for project unit tests and coverage (if desired)
 basepython =
-    py37: python3.7
     py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11
+    py312: python3.12
     py: python3
     {style,reformat,doc,build}: python3
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ python =
     3.10: style,py310-coverage,doc
     3.11: style,py311-coverage,doc
     3.12: style,py312-coverage,doc
-    py3.12-cov-only: py312-coverage
 
 [testenv]
 description = Checks for project unit tests and coverage (if desired)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 description = Default tox environments list
 envlist =
-    style,{py38,py39,py310,py311,py12}{,-coverage},doc
+    style,{py38,py39,py310,py311,py312}{,-coverage},doc
 skip_missing_interpreters = true
 isolated_build = true
 isolated_build_env = build

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 description = Default tox environments list
 envlist =
-    style,{py37,py38,py39,py310}{,-coverage},doc
+    style,{py37,py38,py39,py310,py311}{,-coverage},doc
 skip_missing_interpreters = true
 isolated_build = true
 isolated_build_env = build
@@ -13,6 +13,7 @@ python =
     3.8: style,py38-coverage,doc
     3.9: style,py39-coverage,doc
     3.10: style,py310-coverage,doc
+    3.11: style,py311-coverage,doc
 
 [testenv]
 description = Checks for project unit tests and coverage (if desired)
@@ -21,6 +22,7 @@ basepython =
     py38: python3.8
     py39: python3.9
     py310: python3.10
+    py311: python3.11
     py: python3
     {style,reformat,doc,build}: python3
 setenv =


### PR DESCRIPTION
More recent versions of Sphinx require Python 3.11 to run, so this changes the CI from running in 3.10 to 3.12.