### PR TITLE
ci: do not avoid checking lincenses

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -56,7 +56,7 @@ jobs:
           operating-system: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
           # License check requires 3.10 or above
-          check-licenses: ${{ ! matrix.python-version == '3.9' }}
+          check-licenses: ${{ matrix.python-version != '3.9' }}
 
   tests:
     name: Tests and coverage


### PR DESCRIPTION
If there is a specific reason so not check a license please let us know in this PR. Otherwise this should be enabled as soon as possible.