### PR TITLE
Update pip install instructions for editable mode.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,7 +131,7 @@ To install in developer mode, complete these steps:
 
     .. code:: bash
     
-        python -m pip install --editable .
+        python -m pip install --editable .[tests,doc]
     
 #. Verify your development installation with this command:
 

--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,7 @@ To install in developer mode, complete these steps:
     .. code:: bash
 
         git clone https://github.com/ansys/pymotorcad
+        cd pymotorcad
 
 #. Create a fresh-clean Python environment and then activate it with these
    commands:
@@ -130,7 +131,7 @@ To install in developer mode, complete these steps:
 
     .. code:: bash
     
-        python -m pip install --editable ansys-motorcad-core
+        python -m pip install --editable .
     
 #. Verify your development installation with this command:
 

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -20,7 +20,7 @@ Run this code to clone and install the latest version of PyMotorCAD in developme
 
     git clone https://github.com/ansys/pymotorcad
     cd pymotorcad
-    pip install --editable ansys-motorcad-core
+    pip install --editable .
 
 
 Post issues

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -20,7 +20,7 @@ Run this code to clone and install the latest version of PyMotorCAD in developme
 
     git clone https://github.com/ansys/pymotorcad
     cd pymotorcad
-    pip install --editable .
+    pip install --editable .[tests,doc]
 
 
 Post issues


### PR DESCRIPTION
The old instructions to use `python -m pip install --editable ansys-motorcad-core` don't work, as the --editable option requires a path, instead of a package name. As long as we are in the correct directory, this path can just be `.`.