### PR TITLE
Add DataTypes enum for filtering datastore class

### DIFF
--- a/src/ansys/motorcad/core/datastore.py
+++ b/src/ansys/motorcad/core/datastore.py
@@ -22,6 +22,21 @@
 
 """Contains data classes for getting whole datastore from Motor-CAD."""
 
+from enum import Enum
+
+
+class DataTypes(Enum):
+    """enumerators of Input/Output category for datastore filtering."""
+
+    input = [0, 1, 6]
+    output = 2
+    settings = 3
+    persistent = 4
+    deprecated = 5
+    compatibility = [7, 8, 9, 10, 11, 12]
+    recommended = [13, 14, 15, 16, 17]
+    unsupported = [18, 19, 20, 21, 22, 23]
+
 
 class DataStoreRecord:
     """Object to store data records from Motor-CAD.
@@ -93,8 +108,9 @@ class DataStoreRecord:
 
         Parameters
         ----------
-        inout_list : list | None
-            list of integers that define the data type (e.g. input type, compatibility type, etc).
+        inout_list : list[DataTypes] | None
+            list of DataType enum that define the data type (e.g. DataTypes.input,
+            DataTypes.compatibility, etc).
 
         Returns
         -------
@@ -103,7 +119,17 @@ class DataStoreRecord:
         if inout_list is None:
             return True
         else:
-            return self.input_or_output_type in inout_list
+            result = False
+            for inout_type in inout_list:
+                if isinstance(inout_type.value, list):
+                    if self.input_or_output_type in inout_type.value:
+                        result = True
+                        break
+                else:
+                    if self.input_or_output_type is inout_type.value:
+                        result = True
+                        break
+            return result
 
     def to_json(self):
         """Convert DatastoreRecord to a serialisable dictionary for JSON export.

--- a/src/ansys/motorcad/core/methods/rpc_methods_general.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_general.py
@@ -85,6 +85,20 @@ class _RpcMethodsGeneral:
         params = [directory_path]
         return self.connection.send_and_receive(method, params)
 
+    def load_reduced_nodes(self, file_path):
+        """Load reduced nodes selection from a file.
+
+        Parameters
+        ----------
+        file_path : str
+            Filepath for loading the file with the enabled nodes.
+            Use the ``r'filepath'`` syntax to force Python to ignore
+            special characters.
+        """
+        method = "LoadReducedNodes"
+        params = [file_path]
+        return self.connection.send_and_receive(method, params)
+
     def load_custom_drive_cycle(self, file_path):
         """Load a custom waveform from a file.
 

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -81,6 +81,20 @@ def test_export_matrices(mc):
     assert os.path.exists(get_temp_files_dir_path() + r"\temp_test_file.tmf")
 
 
+def test_load_reduced_nodes(mc):
+    mc.load_reduced_nodes(get_temp_files_dir_path() + r"\ReducedNodes.rnm")
+
+    node_selection = mc.get_variable("ReducedNodeSelection")
+    reduced_nodes_len = mc.get_variable("ReducedNodeNumber")
+    reduced_nodes = [
+        mc.get_array_variable("ReducedNode_NodesToKeep", node) for node in range(reduced_nodes_len)
+    ]
+
+    assert node_selection == 2
+    assert reduced_nodes_len == 7
+    assert reduced_nodes == [1, 2, 3, 6, 7, 126, 127]
+
+
 def test_load_fea_result(mc):
     mc.show_magnetic_context()
 


### PR DESCRIPTION
Enhance the datastore functionality by adding a class of enum for the data types, as they are just numerical without any real relation to the automation parameter list.