### PR TITLE
Change the default colour attribute of new Region objects

### DIFF
--- a/src/ansys/motorcad/core/geometry.py
+++ b/src/ansys/motorcad/core/geometry.py
@@ -131,7 +131,7 @@ class Region(object):
         self._name = ""
         self._base_name = ""
         self._material = "air"
-        self._colour = (0, 0, 0)
+        self._colour = (255, 255, 255)
         self._area = 0.0
         self._centroid = Coordinate(0, 0)
         self._region_coordinate = Coordinate(0, 0)


### PR DESCRIPTION
By default new Regions are created with colour = (0, 0, 0)

This displays as black, and with new draw_objects updates, it makes seeing labels/points difficult, as well as overlapping regions: 
<img width="1395" height="1496" alt="image" src="https://github.com/user-attachments/assets/af726a76-6667-41d9-9e0f-318926e99c22" />

Propose changing this to white = (255, 255, 255) for easier visibility.
<img width="1393" height="1507" alt="image" src="https://github.com/user-attachments/assets/3ed0065e-8e53-40cd-8f32-6e713dfa1fd0" />
