### PR TITLE
Remove bare exceptions from round_corner.

### DIFF
--- a/src/ansys/motorcad/core/geometry.py
+++ b/src/ansys/motorcad/core/geometry.py
@@ -801,13 +801,13 @@ class Region(object):
                 adj_entity_indices.append(index)
         # If no adjacent entities are found, the point provided is not a corner
         if not adj_entities:
-            raise Exception(
+            raise ValueError(
                 "Failed to find point on entity in region. "
                 "You must specify a corner in this region."
             )
         # If only one adjacent entity is found, the point provided is not a corner
         if len(adj_entities) == 1:
-            raise Exception(
+            raise ValueError(
                 "Point found on only one entity in region. "
                 "You must specify a corner in this region."
             )
@@ -881,14 +881,14 @@ class Region(object):
 
         # Raise assertion if not converged, as radius probably not valid
         if converged == False:
-            raise Exception("Cannot find intersection. Check if radius is too large")
+            raise ValueError("Cannot find intersection. Check if radius is too large")
 
         # check that the  distances by which the adjacent entities are shortened are less than the
         # lengths of the adjacent entities.
         for index in range(len(adj_entities)):
             j = adj_entities[index]
             if j.length < distance:
-                raise Exception(
+                raise ValueError(
                     "Corner radius is too large for these entities. "
                     "You must specify a smaller radius."
                 )

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1639,16 +1639,16 @@ def test_round_corners():
             assert not entity.coordinate_on_entity(corners[i])
 
     # check exception is raised when a point that is not a corner is specified
-    with pytest.raises(Exception):
-        triangle_1.round_corner(corners[0], radius)
-    with pytest.raises(Exception):
-        triangle_1.round_corner(triangle_1.entities[0].midpoint, radius)
+    with pytest.raises(ValueError):
+        triangle_1.round_corner(corners[0], corner_radius)
+    with pytest.raises(ValueError):
+        triangle_1.round_corner(triangle_1.entities[0].midpoint, corner_radius)
 
     # check exception is raised when the corner radius is too large
     # this is the case when the distance by which an original entity is to be shortened is larger
     # than the entity's original length
-    with pytest.raises(Exception):
-        triangle_2.round_corner(triangle_2.entities[0].end, 100 * radius)
+    with pytest.raises(ValueError):
+        triangle_2.round_corner(triangle_2.entities[0].end, 100 * corner_radius)
 
 
 def test_round_corner_2():


### PR DESCRIPTION
Bare Exceptions are bad practice. The variable ```radius``` didn't exist but the bare ```Exception``` was capturing the ```NameError```.