### PR TITLE
Samples - do not use Message Display pop up dialogs

### DIFF
--- a/samples/general/BridgeStressSampling.py
+++ b/samples/general/BridgeStressSampling.py
@@ -42,6 +42,7 @@ mcApp = pymotorcad.MotorCAD()
 # Users should run this script from the scripting tab after the stress calculation
 # Trigger this automatically for the automated documentation build
 if "PYMOTORCAD_DOCS_BUILD" in os.environ:
+    mcApp.set_variable("MessageDisplayState", 2)
     mcApp.load_template("e10")
     mcApp.do_mechanical_calculation()
 

--- a/samples/general/MotionForceExport.py
+++ b/samples/general/MotionForceExport.py
@@ -691,6 +691,7 @@ slice_centre_z = 0
 # Alternatively, this could be changed to pymotorcad.MotorCAD(open_new_instance=False) to connect
 # to an existing instance if running from an external IDE.
 mc = pymotorcad.MotorCAD()
+mc.set_variable("MessageDisplayState", 2)
 
 if mc.get_variable("SkewType") == 2:
     # Rotor skew type

--- a/samples/general/ParameterSweepSync.py
+++ b/samples/general/ParameterSweepSync.py
@@ -33,6 +33,7 @@ import ansys.motorcad.core as pymotorcad
 
 # Open connection to Motor-CAD, and open e3 template (Sync machine)
 mc = pymotorcad.MotorCAD()
+mc.set_variable("MessageDisplayState", 2)
 mc.load_template("e3")
 # Alternatively, use the following
 # mc = pymotorcad.MotorCAD()


### PR DESCRIPTION
Added **set_variable("MessageDisplayState", 2)** to samples.

Otherwise, samples can stall when running docs build