### PR TITLE
Add version checks to new Motor-CAD API methods

### DIFF
--- a/src/ansys/motorcad/core/methods/adaptive_geometry.py
+++ b/src/ansys/motorcad/core/methods/adaptive_geometry.py
@@ -319,17 +319,20 @@ class _RpcMethodsAdaptiveGeometry:
         ansys.motorcad.core.geometry.GeometryTree
             Motor-CAD geometry tree
         """
+        self.connection.ensure_version_at_least("2026.0")
         method = "GetGeometryTree"
         json = self.connection.send_and_receive(method)
         return GeometryTree._from_json(json, self)
 
     def set_geometry_tree(self, tree: GeometryTree):
         """Use a GeometryTree object to set the defining geometry of the loaded motor."""
+        self.connection.ensure_version_at_least("2026.0")
         params = [tree._to_json()]
         method = "SetGeometryTree"
         return self.connection.send_and_receive(method, params)
 
     def get_maxwell_udm_geometry_json(self):
         """Fetch a dict defining Maxwell UDM geometry."""
+        self.connection.ensure_version_at_least("2026.0")
         method = "GetGeometryTree_Maxwell_UDM"
         return self.connection.send_and_receive(method)

--- a/src/ansys/motorcad/core/methods/rpc_methods_variables.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_variables.py
@@ -174,6 +174,7 @@ class _RpcMethodsVariables:
         -------
         ansys.motorcad.core.datastore.Datastore
         """
+        self.connection.ensure_version_at_least("2026.0")
         method = "GetDataStore"
         datastore_json = self.connection.send_and_receive(method)
         return Datastore.from_json(datastore_json)


### PR DESCRIPTION
Closes #617
There were a few new methods that weren't checking the Motor-CAD version.

This PR doesn't check if the user sets magnetisation_direction, I think we will need to add a setter if we want to do this.