### PR TITLE
Make default Br multiplier = 1 for RegionMagnet

### DIFF
--- a/src/ansys/motorcad/core/geometry.py
+++ b/src/ansys/motorcad/core/geometry.py
@@ -1325,7 +1325,7 @@ class RegionMagnet(Region):
         """Initialise Magnet Region."""
         super().__init__(RegionType.magnet, motorcad_instance)
         self._magnet_angle = 0.0
-        self._br_multiplier = 0.0
+        self._br_multiplier = 1.0
         self._br_magnet = 0.0
         self._magnet_polarity = ""
         self.magnetisation_direction = MagnetisationDirection.parallel


### PR DESCRIPTION
Currently if you create a new RegionMagnet, the br_multiplier = 0.
It makes sense for the default value to be 1, not 0.

In most cases users would want to set it to 1, so it saves time and effort if the default is 1. This avoids confusion if the user forgets to set it as well.

It would be a very rare case where the user wants to set it to 0.