### PR TITLE
Remove docs build from Python 3.9 tests.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ isolated_build_env = build
 [gh-actions]
 description = The tox environment to be executed in gh-actions for a given python version
 python =
-    3.9: style,py39-coverage,doc
+    3.9: style,py39-coverage
     3.10: style,py310-coverage,doc
     3.11: style,py311-coverage,doc
     3.12: style,py312-coverage,doc


### PR DESCRIPTION
The nightly build test runs on Python 3.9 to 3.14. However, the sphinx version we use isn't available for 3.9. This PR removes the docs build from the Python 3.9 tests, but still runs the main regression tests. This should avoid the nightly check routinely failing.