### PR TITLE
Fix thermal transient internal script example

### DIFF
--- a/examples/internal_scripting/setup_scripts/setup_script.py
+++ b/examples/internal_scripting/setup_scripts/setup_script.py
@@ -189,6 +189,9 @@ def run_thermal_transient_demo(mc):
     mc.set_variable("Simple_Transient_Definition", 1)
     mc.set_variable("Simple_Transient_Torque", 100)
     # %%
+    # Set transient endpoint definition to Fixed Duration (default)
+    mc.set_variable("EndPoint_Definition", 0)
+    # %%
     # Solve thermal model
     mc.do_transient_analysis()
 


### PR DESCRIPTION
Set fixed duration endpoint definition, which is compatible with the Run During Analysis scripting option.

This should fix an issue with the example that is causing documentation build to fail.