### PR TITLE
Comment out failing tests

### DIFF
--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -619,16 +619,18 @@ def test_region_set_parent(mc):
     assert square.name in shaft_expected._child_names
 
 
-def test_region_children(mc):
-    rotor = mc.get_region("rotor")
-    children = rotor.children
+# commented out as functionality requires updated Motor-CAD version
+# def test_region_children(mc):
+#     rotor = mc.get_region("rotor")
+#     children = rotor.children
 
-    assert len(children) == 16
+#     assert len(children) == 16
 
 
-def test_region_linked_regions(mc):
-    duct = mc.get_region("RotorDuctFluidRegion_1", get_linked=True)
-    assert len(duct.linked_regions) == 1
+# commented out as functionality requires updated Motor-CAD version
+# def test_region_linked_regions(mc):
+#     duct = mc.get_region("RotorDuctFluidRegion_1", get_linked=True)
+#     assert len(duct.linked_regions) == 1
 
 
 def test_reverse_entity():


### PR DESCRIPTION
## Title
Comment out tests requiring updated Motor-CAD version

## Description

Temporarily disables two tests in test_geometry.py that depend on functionality not available in the current Motor-CAD version used by CI:

- `test_region_children` — relies on `Region.children` returning child regions of the rotor.
- `test_region_linked_regions` — relies on `get_region(..., get_linked=True)` populating `linked_regions`.

Both tests are commented out (rather than removed) with a note explaining they require an updated Motor-CAD version, so they can easily be re-enabled once the supported Motor-CAD version is bumped.

### Why
These tests are currently failing against the Motor-CAD version available in CI because the underlying APIs have changed. Commenting them out unblocks the test suite.