### PR TITLE
Add  `context` parameter to `check_if_geometry_is_valid` API

### DIFF
--- a/src/ansys/motorcad/core/__init__.py
+++ b/src/ansys/motorcad/core/__init__.py
@@ -26,8 +26,8 @@ try:
 except ModuleNotFoundError:  # pragma: no cover
     import importlib_metadata
 
-import ansys.motorcad.core.geometry
 from ansys.motorcad.core.enums import MotorCADContext
+import ansys.motorcad.core.geometry
 from ansys.motorcad.core.motorcad_methods import MotorCAD, MotorCADCompatibility
 from ansys.motorcad.core.rpc_client_core import (
     MotorCADError,

--- a/src/ansys/motorcad/core/__init__.py
+++ b/src/ansys/motorcad/core/__init__.py
@@ -27,6 +27,7 @@ except ModuleNotFoundError:  # pragma: no cover
     import importlib_metadata
 
 import ansys.motorcad.core.geometry
+from ansys.motorcad.core.enums import MotorCADContext
 from ansys.motorcad.core.motorcad_methods import MotorCAD, MotorCADCompatibility
 from ansys.motorcad.core.rpc_client_core import (
     MotorCADError,

--- a/src/ansys/motorcad/core/enums.py
+++ b/src/ansys/motorcad/core/enums.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Enumerations for Motor-CAD."""
+from enum import Enum
+
+
+class MotorCADContext(str, Enum):
+    """Provides an enumeration for Motor-CAD analysis context."""
+
+    magnetic = "Magnetic"
+    thermal = "Thermal"
+    mechanical = "Mechanical"

--- a/src/ansys/motorcad/core/methods/rpc_methods_geometry.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_geometry.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 """RPC methods for geometry."""
-from ansys.motorcad.core.rpc_client_core import MotorCADError
+from ansys.motorcad.core.rpc_client_core import MotorCADWarning
 
 
 class _RpcMethodsGeometry:
@@ -112,9 +112,10 @@ class _RpcMethodsGeometry:
         """
         if self.connection.check_version_at_least("2027.0"):
             if context == "":
-                raise MotorCADError(
-                    "Context must be specified for geometry_export for Motor-CAD version "
-                    "2027R1 and later."
+                raise MotorCADWarning(
+                    "It is recommended to specify the context for check_if_geometry_is_valid" \
+                    " with Motor-CAD 2027.0 or later. If no context is specified, the geometry" \
+                    " will be checked for the current UI context, this not work for headless mode."
                 )
             method = "CheckIfGeometryIsValidWithContext"
             params = [edit_geometry, context]

--- a/src/ansys/motorcad/core/methods/rpc_methods_geometry.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_geometry.py
@@ -110,7 +110,6 @@ class _RpcMethodsGeometry:
         int
             ``1`` if an attempt to reset the geometry has been made, ``O`` otherwise.
         """
-
         if self.connection.check_version_at_least("2027.0"):
             if context == "":
                 raise MotorCADError(

--- a/src/ansys/motorcad/core/methods/rpc_methods_geometry.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_geometry.py
@@ -100,10 +100,10 @@ class _RpcMethodsGeometry:
 
             - ``1``: Yes. Try and reset the geometry
             - ``0``: No. Do not try to reset the geometry.
-        context : str, optional
+        context : str or MotorCADContext, optional
             Context for which to check the geometry. If not specified, the geometry
-            will be checked for the current context. Options are ``"Magnetic"``, ``"Thermal"``
-            and ``"Mechanical"``.
+            will be checked for the current context. Use :class:`MotorCADContext` or the
+            equivalent strings ``"Magnetic"``, ``"Thermal"`` and ``"Mechanical"``.
 
         Returns
         -------

--- a/src/ansys/motorcad/core/methods/rpc_methods_geometry.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_geometry.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 """RPC methods for geometry."""
+from ansys.motorcad.core.rpc_client_core import MotorCADError
 
 
 class _RpcMethodsGeometry:
@@ -88,7 +89,7 @@ class _RpcMethodsGeometry:
         params = [phase, path, coil]
         return self.connection.send_and_receive(method, params)
 
-    def check_if_geometry_is_valid(self, edit_geometry):
+    def check_if_geometry_is_valid(self, edit_geometry, context=""):
         """Check if the Motor-CAD geometry is valid.
 
         Parameters
@@ -99,12 +100,27 @@ class _RpcMethodsGeometry:
 
             - ``1``: Yes. Try and reset the geometry
             - ``0``: No. Do not try to reset the geometry.
+        context : str, optional
+            Context for which to check the geometry. If not specified, the geometry
+            will be checked for the current context. Options are ``"Magnetic"``, ``"Thermal"``
+            and ``"Mechanical"``.
 
         Returns
         -------
         int
             ``1`` if an attempt to reset the geometry has been made, ``O`` otherwise.
         """
-        method = "CheckIfGeometryIsValid"
-        params = [edit_geometry]
+
+        if self.connection.check_version_at_least("2027.0"):
+            if context == "":
+                raise MotorCADError(
+                    "Context must be specified for geometry_export for Motor-CAD version "
+                    "2027R1 and later."
+                )
+            method = "CheckIfGeometryIsValidWithContext"
+            params = [edit_geometry, context]
+        else:
+            method = "CheckIfGeometryIsValid"
+            params = [edit_geometry]
+
         return self.connection.send_and_receive(method, params)

--- a/src/ansys/motorcad/core/methods/rpc_methods_geometry.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_geometry.py
@@ -113,8 +113,8 @@ class _RpcMethodsGeometry:
         if self.connection.check_version_at_least("2027.0"):
             if context == "":
                 raise MotorCADWarning(
-                    "It is recommended to specify the context for check_if_geometry_is_valid" \
-                    " with Motor-CAD 2027.0 or later. If no context is specified, the geometry" \
+                    "It is recommended to specify the context for check_if_geometry_is_valid"
+                    " with Motor-CAD 2027.0 or later. If no context is specified, the geometry"
                     " will be checked for the current UI context, this not work for headless mode."
                 )
             method = "CheckIfGeometryIsValidWithContext"

--- a/src/ansys/motorcad/core/rpc_client_core.py
+++ b/src/ansys/motorcad/core/rpc_client_core.py
@@ -594,7 +594,7 @@ class _MotorCADConnection:
             else:
                 success = response["result"]["success"]
 
-            if method == "CheckIfGeometryIsValid":
+            if (method == "CheckIfGeometryIsValid") or (method == "CheckIfGeometryIsValidWithContext"):
                 # This doesn't have the normal success var
                 success_value = 1
             else:

--- a/src/ansys/motorcad/core/rpc_client_core.py
+++ b/src/ansys/motorcad/core/rpc_client_core.py
@@ -594,7 +594,9 @@ class _MotorCADConnection:
             else:
                 success = response["result"]["success"]
 
-            if (method == "CheckIfGeometryIsValid") or (method == "CheckIfGeometryIsValidWithContext"):
+            if (method == "CheckIfGeometryIsValid") or (
+                method == "CheckIfGeometryIsValidWithContext"
+            ):
                 # This doesn't have the normal success var
                 success_value = 1
             else:

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -30,6 +30,7 @@ import pytest
 
 from RPC_Test_Common import get_dir_path
 from ansys.motorcad.core import MotorCADError, geometry
+from ansys.motorcad.core.enums import MotorCADContext
 from ansys.motorcad.core.geometry import (
     GEOM_TOLERANCE,
     Arc,
@@ -144,7 +145,7 @@ def test_set_get_winding_coil(mc):
 def test_check_if_geometry_is_valid(mc):
     # base_test_file should have valid geometry
     if mc.connection.check_version_at_least("2027.0"):
-        mc.check_if_geometry_is_valid(0, "Magnetic")
+        mc.check_if_geometry_is_valid(0, MotorCADContext.magnetic)
     else:
         mc.check_if_geometry_is_valid(0)
 
@@ -153,13 +154,13 @@ def test_check_if_geometry_is_valid(mc):
     mc.set_variable("Slot_Depth", 50)
     with pytest.raises(MotorCADError):
         if mc.connection.check_version_at_least("2027.0"):
-            mc.check_if_geometry_is_valid(0, "Magnetic")
+            mc.check_if_geometry_is_valid(0, MotorCADContext.magnetic)
         else:
             mc.check_if_geometry_is_valid(0)
 
     # Check resetting geometry works
     if mc.connection.check_version_at_least("2027.0"):
-        mc.check_if_geometry_is_valid(1, "Magnetic")
+        mc.check_if_geometry_is_valid(1, MotorCADContext.magnetic)
     else:
         mc.check_if_geometry_is_valid(1)
 

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -143,16 +143,25 @@ def test_set_get_winding_coil(mc):
 
 def test_check_if_geometry_is_valid(mc):
     # base_test_file should have valid geometry
-    mc.check_if_geometry_is_valid(0)
+    if mc.connection.check_version_at_least("2027.0"):
+        mc.check_if_geometry_is_valid(0, "Magnetic")
+    else:
+        mc.check_if_geometry_is_valid(0)
 
     save_slot_depth = mc.get_variable("Slot_Depth")
 
     mc.set_variable("Slot_Depth", 50)
     with pytest.raises(MotorCADError):
-        mc.check_if_geometry_is_valid(0)
+        if mc.connection.check_version_at_least("2027.0"):
+            mc.check_if_geometry_is_valid(0, "Magnetic")
+        else:
+            mc.check_if_geometry_is_valid(0)
 
     # Check resetting geometry works
-    mc.check_if_geometry_is_valid(1)
+    if mc.connection.check_version_at_least("2027.0"):
+        mc.check_if_geometry_is_valid(1, "Magnetic")
+    else:
+        mc.check_if_geometry_is_valid(1)
 
     mc.set_variable("Slot_Depth", save_slot_depth)
 


### PR DESCRIPTION
## Summary

Adds an optional `context` parameter to `check_if_geometry_is_valid` to support Motor-CAD 2027R1+, which introduces a new RPC endpoint (`CheckIfGeometryIsValidWithContext`) requiring an explicit geometry context.

## Changes

- **`rpc_methods_geometry.py`**: Updated `check_if_geometry_is_valid` to accept a `context` parameter (`"Magnetic"`, `"Thermal"`, or `"Mechanical"`). For Motor-CAD 2027.0+, the context is required and the new `CheckIfGeometryIsValidWithContext` RPC method is called. For earlier versions, behavior is unchanged.
- **`rpc_client_core.py`**: Extended the special-case success handling to also recognise `CheckIfGeometryIsValidWithContext` alongside `CheckIfGeometryIsValid`.
- **test_geometry.py**: Updated `test_check_if_geometry_is_valid` to call the correct API variant based on the connected Motor-CAD version.

## Notes

- A `MotorCADError` is raised if `context` is omitted when connected to Motor-CAD 2027R1 or later, as the legacy endpoint is no longer available in that version.

---

