### PR TITLE
Add success var geometry check

### DIFF
--- a/src/ansys/motorcad/core/methods/rpc_methods_geometry.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_geometry.py
@@ -115,7 +115,7 @@ class _RpcMethodsGeometry:
                 raise MotorCADWarning(
                     "It is recommended to specify the context for check_if_geometry_is_valid"
                     " with Motor-CAD 2027.0 or later. If no context is specified, the geometry"
-                    " will be checked for the current UI context, this not work for headless mode."
+                    " will be checked for the current UI context, this will not work for headless mode."
                 )
             method = "CheckIfGeometryIsValidWithContext"
             params = [edit_geometry, context]

--- a/src/ansys/motorcad/core/methods/rpc_methods_geometry.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_geometry.py
@@ -115,7 +115,8 @@ class _RpcMethodsGeometry:
                 raise MotorCADWarning(
                     "It is recommended to specify the context for check_if_geometry_is_valid"
                     " with Motor-CAD 2027.0 or later. If no context is specified, the geometry"
-                    " will be checked for the current UI context, this will not work for headless mode."
+                    " will be checked for the current UI context, this will not work for headless"
+                    " mode."
                 )
             method = "CheckIfGeometryIsValidWithContext"
             params = [edit_geometry, context]
@@ -123,4 +124,4 @@ class _RpcMethodsGeometry:
             method = "CheckIfGeometryIsValid"
             params = [edit_geometry]
 
-        return self.connection.send_and_receive(method, params)
+        return self.connection.send_and_receive(method, params, success_var=True)


### PR DESCRIPTION
Previously the success variable was not returned from the check_if_geometry_is_valid as the success_var parameter was not being set to true.

By setting this we now return the value set from Motor-CAD back to the user