### PR TITLE
Doc: Getting Started & ecosystem links

### DIFF
--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -25,6 +25,13 @@ Installation
 
 Python module
 --------------
+
+.. note::
+   These instructions assume you are familiar
+   with ``pip`` and the command line. If they are new to you, you should read
+   the `Python Packaging User Guide Tutorial on pip <https://packaging.python.org/en/latest/tutorials/installing-packages/>`_
+   before proceeding.
+
 The ``ansys.motorcad.core`` package currently supports Python 3.9 through Python 3.14 on Windows.
 
 Install the latest release from

--- a/doc/source/user_guide/troubleshooting.rst
+++ b/doc/source/user_guide/troubleshooting.rst
@@ -63,3 +63,14 @@ Check the registration form to see which version is registered.
 
 .. image:: /_static/troubleshooting_automation_dropdown.png
     :width: 600
+
+Ansys developer ecosystem resources
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Ansys has an extensive developer ecosystem where you can find assistance for a variety of issues.
+
+- `Developer Portal <https://developer.ansys.com/>`_: Blog posts, documentation, and guide
+- `Developer Forum <https://discuss.ansys.com/>`_: Scripting and usage support for PyAnsys and other Ansys developer tools
+- `Ansys Innovation Space <https://innovationspace.ansys.com/>`_: Product support forum and training materials
+- `GitHub <https://github.com/ansys/pymechanical>`_: Development support, bug reporting, feature requests, and more.
+- `Ansys Learning Hub <https://learninghub.ansys.com/>`_: Training, courses and learning plans

--- a/doc/source/user_guide/troubleshooting.rst
+++ b/doc/source/user_guide/troubleshooting.rst
@@ -72,5 +72,5 @@ Ansys has an extensive developer ecosystem where you can find assistance for a v
 - `Developer Portal <https://developer.ansys.com/>`_: Blog posts, documentation, and guide
 - `Developer Forum <https://discuss.ansys.com/>`_: Scripting and usage support for PyAnsys and other Ansys developer tools
 - `Ansys Innovation Space <https://innovationspace.ansys.com/>`_: Product support forum and training materials
-- `GitHub <https://github.com/ansys/pymechanical>`_: Development support, bug reporting, feature requests, and more.
+- `GitHub <https://github.com/ansys/pymotorcad>`_: Development support, bug reporting, feature requests, and more.
 - `Ansys Learning Hub <https://learninghub.ansys.com/>`_: Training, courses and learning plans


### PR DESCRIPTION
I am currently working on reviewing and improving PyAnsys Getting Started sections and this work is part of that. It is reasonable to assume new users of PyMotorCAD will be familiar with Python and pip but not guaranteed. So I have added a note + link that makes it clearer what those items are for people that don't know when they first get mentioned in the docs.

In addition, I have added a section on the Ansys wider developer ecosystem to the troubleshooting section including a set of links to places where users can expect to find resources that may be of assistance, such as the portal, forum AIS, ALH, etc.