### PR TITLE
Enable geometry check context for Motor-CAD 2027.0+

### DIFF
--- a/src/ansys/motorcad/core/methods/rpc_methods_geometry.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_geometry.py
@@ -111,19 +111,19 @@ class _RpcMethodsGeometry:
             ``1`` if an attempt to reset the geometry has been made, ``O`` otherwise.
         """
         # Add this back in when Motor-CAD updated
-        #
-        # if self.connection.check_version_at_least("2027.0"):
-        #     if context == "":
-        #         raise MotorCADWarning(
-        #             "It is recommended to specify the context for check_if_geometry_is_valid"
-        #             " with Motor-CAD 2027.0 or later. If no context is specified, the geometry"
-        #             " will be checked for the current UI context, this will not work for headless mode."
-        #         )
-        #     method = "CheckIfGeometryIsValidWithContext"
-        #     params = [edit_geometry, context]
-        # else:
-        #     method = "CheckIfGeometryIsValid"
-        #     params = [edit_geometry]
+        if (self.connection.check_version_at_least("2027.0") and
+                self.connection.test_feature_exists_check("check_if_geometry_is_valid_with_context")):
+            if context == "":
+                raise MotorCADWarning(
+                    "It is recommended to specify the context for check_if_geometry_is_valid"
+                    " with Motor-CAD 2027.0 or later. If no context is specified, the geometry"
+                    " will be checked for the current UI context, this will not work for headless mode."
+                )
+            method = "CheckIfGeometryIsValidWithContext"
+            params = [edit_geometry, context]
+        else:
+            method = "CheckIfGeometryIsValid"
+            params = [edit_geometry]
 
         method = "CheckIfGeometryIsValid"
         params = [edit_geometry]

--- a/src/ansys/motorcad/core/methods/rpc_methods_geometry.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_geometry.py
@@ -111,13 +111,15 @@ class _RpcMethodsGeometry:
             ``1`` if an attempt to reset the geometry has been made, ``O`` otherwise.
         """
         # Add this back in when Motor-CAD updated
-        if (self.connection.check_version_at_least("2027.0") and
-                self.connection.test_feature_exists_check("check_if_geometry_is_valid_with_context")):
+        if self.connection.check_version_at_least(
+            "2027.0"
+        ) and self.connection.test_feature_exists_check("check_if_geometry_is_valid_with_context"):
             if context == "":
                 raise MotorCADWarning(
                     "It is recommended to specify the context for check_if_geometry_is_valid"
                     " with Motor-CAD 2027.0 or later. If no context is specified, the geometry"
-                    " will be checked for the current UI context, this will not work for headless mode."
+                    " will be checked for the current UI context, this will not work for headless"
+                    " mode."
                 )
             method = "CheckIfGeometryIsValidWithContext"
             params = [edit_geometry, context]

--- a/src/ansys/motorcad/core/methods/rpc_methods_geometry.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_geometry.py
@@ -113,7 +113,7 @@ class _RpcMethodsGeometry:
         # Add this back in when Motor-CAD updated
         if self.connection.check_version_at_least(
             "2027.0"
-        ) and self.connection.test_feature_exists_check("check_if_geometry_is_valid_with_context"):
+        ) and self.connection.check_if_feature_exists("check_if_geometry_is_valid_with_context"):
             if context == "":
                 raise MotorCADWarning(
                     "It is recommended to specify the context for check_if_geometry_is_valid"

--- a/src/ansys/motorcad/core/methods/rpc_methods_geometry.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_geometry.py
@@ -127,7 +127,4 @@ class _RpcMethodsGeometry:
             method = "CheckIfGeometryIsValid"
             params = [edit_geometry]
 
-        method = "CheckIfGeometryIsValid"
-        params = [edit_geometry]
-
         return self.connection.send_and_receive(method, params)

--- a/tests/test_rpc_client_core.py
+++ b/tests/test_rpc_client_core.py
@@ -354,6 +354,6 @@ def test_blackbox_licencing():
 
 
 def test_feature_exists_check(mc):
-    assert mc.connection.check_if_feature_exists("updated_geometry_check") is True
+    #assert mc.connection.check_if_feature_exists("check_if_geometry_is_valid_with_context") is True
 
     assert mc.connection.check_if_feature_exists("not_a_real_feature") is False

--- a/tests/test_rpc_client_core.py
+++ b/tests/test_rpc_client_core.py
@@ -354,6 +354,9 @@ def test_blackbox_licencing():
 
 
 def test_feature_exists_check(mc):
-    #assert mc.connection.check_if_feature_exists("check_if_geometry_is_valid_with_context") is True
+    geo_check_context = mc.connection.check_if_feature_exists(
+        "check_if_geometry_is_valid_with_context"
+    )
+    # assert geo_check_context is True
 
     assert mc.connection.check_if_feature_exists("not_a_real_feature") is False

--- a/tests/test_rpc_client_core.py
+++ b/tests/test_rpc_client_core.py
@@ -357,6 +357,7 @@ def test_feature_exists_check(mc):
     geo_check_context = mc.connection.check_if_feature_exists(
         "check_if_geometry_is_valid_with_context"
     )
+    # todo enable once MotorCAD is updated
     # assert geo_check_context is True
 
     assert mc.connection.check_if_feature_exists("not_a_real_feature") is False


### PR DESCRIPTION

## Summary

Activates the `context` parameter support in `check_if_geometry_is_valid`, enabling it to use the new `CheckIfGeometryIsValidWithContext` RPC method when connecting to Motor-CAD 2027.0 or later with the `check_if_geometry_is_valid_with_context` feature flag present.

Previously, the version-gated routing existed as commented-out code. This PR replaces it with active logic gated on both a version check and a feature flag check. When either condition is not met, the method falls back to the existing `CheckIfGeometryIsValid` RPC call.

A `MotorCADWarning` is raised if `context` is left empty when running with a compatible Motor-CAD version, since an empty context falls back to the current UI context and will not work correctly in headless mode.

## Changes

- **`rpc_methods_geometry.py`**: Uncomments and activates the version + feature flag gating in `check_if_geometry_is_valid`. When Motor-CAD ≥ 2027.0 and the feature flag is present, calls `CheckIfGeometryIsValidWithContext`; otherwise falls back to `CheckIfGeometryIsValid`.
- **test_rpc_client_core.py**: Updates the feature flag name in `test_feature_exists_check` from `updated_geometry_check` to `check_if_geometry_is_valid_with_context`. The positive assertion is temporarily commented out pending a Motor-CAD build that exposes the feature flag.
