### PR TITLE
Add optional context parameter to do_weight_calculation

### DIFF
--- a/src/ansys/motorcad/core/methods/rpc_methods_calculations.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_calculations.py
@@ -116,7 +116,7 @@ class _RpcMethodsCalculations:
 
     def do_weight_calculation(self, context):
         """Run the Motor-CAD weight calculation."""
-        if self.connection.check_if_feature_exists("do_weight_calculation_with_context", "2027.0"):
+        if self.connection.check_if_feature_exists("do_weight_calculation_with_context"):
             if context == "":
                 raise MotorCADWarning(
                     "It is recommended to specify the context for do_weight_calculation"

--- a/src/ansys/motorcad/core/methods/rpc_methods_calculations.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_calculations.py
@@ -116,7 +116,9 @@ class _RpcMethodsCalculations:
 
     def do_weight_calculation(self, context):
         """Run the Motor-CAD weight calculation."""
-        if self.connection.check_version_at_least("2027.1") and self.connection.check_if_feature_exists("do_weight_calculation_with_context"):
+        if self.connection.check_version_at_least(
+            "2027.1"
+        ) and self.connection.check_if_feature_exists("do_weight_calculation_with_context"):
             if context == "":
                 raise MotorCADWarning(
                     "It is recommended to specify the context for do_weight_calculation"

--- a/src/ansys/motorcad/core/methods/rpc_methods_calculations.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_calculations.py
@@ -116,9 +116,7 @@ class _RpcMethodsCalculations:
 
     def do_weight_calculation(self, context):
         """Run the Motor-CAD weight calculation."""
-        if self.connection.check_version_at_least(
-            "2027.1"
-        ) and self.connection.check_if_feature_exists("do_weight_calculation_with_context"):
+        if self.connection.check_if_feature_exists("do_weight_calculation_with_context", "2027.0"):
             if context == "":
                 raise MotorCADWarning(
                     "It is recommended to specify the context for do_weight_calculation"

--- a/src/ansys/motorcad/core/methods/rpc_methods_calculations.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_calculations.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 """RPC methods for calculations."""
+from ansys.motorcad.core.rpc_client_core import MotorCADWarning
 
 
 class _RpcMethodsCalculations:
@@ -113,10 +114,23 @@ class _RpcMethodsCalculations:
         method = "DoMagneticCalculation"
         return self.connection.send_and_receive(method)
 
-    def do_weight_calculation(self):
+    def do_weight_calculation(self, context):
         """Run the Motor-CAD weight calculation."""
-        method = "DoWeightCalculation"
-        return self.connection.send_and_receive(method)
+        if self.connection.check_version_at_least("2027.1") and self.connection.check_if_feature_exists("do_weight_calculation_with_context"):
+            if context == "":
+                raise MotorCADWarning(
+                    "It is recommended to specify the context for do_weight_calculation"
+                    " with Motor-CAD 2027.0 or later. If no context is specified, the calculation"
+                    " will be checked for the current UI context, this will not work for headless"
+                    " mode."
+                )
+            method = "DoWeightCalculationWithContext"
+            params = [context]
+        else:
+            method = "DoWeightCalculation"
+            params = []
+
+        return self.connection.send_and_receive(method, params)
 
     def do_mechanical_calculation(self):
         """Run the Motor-CAD mechanical calculation."""

--- a/src/ansys/motorcad/core/methods/rpc_methods_geometry.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_geometry.py
@@ -111,9 +111,7 @@ class _RpcMethodsGeometry:
             ``1`` if an attempt to reset the geometry has been made, ``O`` otherwise.
         """
         # Add this back in when Motor-CAD updated
-        if self.connection.check_if_feature_exists(
-            "check_if_geometry_is_valid_with_context", "2027.0"
-        ):
+        if self.connection.check_if_feature_exists("check_if_geometry_is_valid_with_context"):
             if context == "":
                 raise MotorCADWarning(
                     "It is recommended to specify the context for check_if_geometry_is_valid"

--- a/src/ansys/motorcad/core/methods/rpc_methods_geometry.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_geometry.py
@@ -111,9 +111,9 @@ class _RpcMethodsGeometry:
             ``1`` if an attempt to reset the geometry has been made, ``O`` otherwise.
         """
         # Add this back in when Motor-CAD updated
-        if self.connection.check_version_at_least(
-            "2027.0"
-        ) and self.connection.check_if_feature_exists("check_if_geometry_is_valid_with_context"):
+        if self.connection.check_if_feature_exists(
+            "check_if_geometry_is_valid_with_context", "2027.0"
+        ):
             if context == "":
                 raise MotorCADWarning(
                     "It is recommended to specify the context for check_if_geometry_is_valid"

--- a/src/ansys/motorcad/core/rpc_client_core.py
+++ b/src/ansys/motorcad/core/rpc_client_core.py
@@ -517,7 +517,7 @@ class _MotorCADConnection:
         else:
             return version.parse(self.program_version) >= version.parse(required_version)
 
-    def check_if_feature_exists(self, feature_name, required_version):
+    def check_if_feature_exists(self, feature_name):
         """Check if the Motor-CAD feature is present.
 
         Useful for development versions where PyMotorCAD and Motor-CAD have circular

--- a/src/ansys/motorcad/core/rpc_client_core.py
+++ b/src/ansys/motorcad/core/rpc_client_core.py
@@ -531,9 +531,11 @@ class _MotorCADConnection:
             Minimum version of Motor-CAD required for the feature to exist.
 
         """
-        return self.check_version_at_least(required_version) and self.send_and_receive(
-            "CheckIfFeatureExists", [feature_name]
-        )
+        if self.check_version_at_least("2027.0"):
+            return self.send_and_receive("CheckIfFeatureExists", [feature_name])
+        else:
+            # Version of Motor-CAD is definitely too old for this feature
+            return False
 
     def _wait_for_server_to_start_local(self, process):
         number_of_tries = 0

--- a/src/ansys/motorcad/core/rpc_client_core.py
+++ b/src/ansys/motorcad/core/rpc_client_core.py
@@ -517,13 +517,23 @@ class _MotorCADConnection:
         else:
             return version.parse(self.program_version) >= version.parse(required_version)
 
-    def check_if_feature_exists(self, feature_name):
+    def check_if_feature_exists(self, feature_name, required_version):
         """Check if the Motor-CAD feature is present.
 
-        Useful for development versions where PyMotorCAD and Motor-CAD have circular dependencies
-        for testing.
+        Useful for development versions where PyMotorCAD and Motor-CAD have circular
+        dependencies for testing.
+        Parameters
+        ----------
+        feature_name : str
+            Name of the feature to check.
+
+        required_version : str
+            Minimum version of Motor-CAD required for the feature to exist.
+
         """
-        return self.send_and_receive("CheckIfFeatureExists", [feature_name])
+        return self.check_version_at_least(required_version) and self.send_and_receive(
+            "CheckIfFeatureExists", [feature_name]
+        )
 
     def _wait_for_server_to_start_local(self, process):
         number_of_tries = 0

--- a/tests/test_calculations.py
+++ b/tests/test_calculations.py
@@ -23,6 +23,7 @@
 # import os
 
 from RPC_Test_Common import almost_equal, almost_equal_fixed, get_dir_path
+from ansys.motorcad.core.enums import MotorCADContext
 
 
 def test_do_magnetic_thermal_calculation(mc):
@@ -77,7 +78,11 @@ def test_calculate_force_harmonics_temporal(mc):
 
 
 def test_do_weight_calculation(mc):
-    mc.do_weight_calculation()
+    if mc.connection.check_version_at_least("2027.0"):
+        mc.do_weight_calculation(MotorCADContext.magnetic)
+        mc.do_weight_calculation(MotorCADContext.thermal)
+    else:
+        mc.do_weight_calculation()
 
 
 def test_create_winding_pattern(mc):

--- a/tests/test_rpc_client_core.py
+++ b/tests/test_rpc_client_core.py
@@ -354,10 +354,10 @@ def test_blackbox_licencing():
 
 
 def test_feature_exists_check(mc):
-    geo_check_context = mc.connection.check_if_feature_exists(
-        "check_if_geometry_is_valid_with_context"
-    )
-    # todo enable once MotorCAD is updated
-    # assert geo_check_context is True
+    if mc.connection.check_version_at_least("2027.0"):
+        geo_check_context = mc.connection.check_if_feature_exists(
+            "check_if_geometry_is_valid_with_context", "2027.0"
+        )
 
-    assert mc.connection.check_if_feature_exists("not_a_real_feature") is False
+        assert geo_check_context is True
+        assert mc.connection.check_if_feature_exists("not_a_real_feature", "2027.0") is False

--- a/tests/test_rpc_client_core.py
+++ b/tests/test_rpc_client_core.py
@@ -356,8 +356,8 @@ def test_blackbox_licencing():
 def test_feature_exists_check(mc):
     if mc.connection.check_version_at_least("2027.0"):
         geo_check_context = mc.connection.check_if_feature_exists(
-            "check_if_geometry_is_valid_with_context", "2027.0"
+            "check_if_geometry_is_valid_with_context"
         )
 
         assert geo_check_context is True
-        assert mc.connection.check_if_feature_exists("not_a_real_feature", "2027.0") is False
+        assert mc.connection.check_if_feature_exists("not_a_real_feature") is False


### PR DESCRIPTION
## Description

Adds an optional `context` parameter to `do_weight_calculation` to support the new `DoWeightCalculationWithContext` Motor-CAD API introduced in Motor-CAD 2027.1.

### Changes

**`rpc_methods_calculations.py`**
- `do_weight_calculation` now accepts a `context` parameter (e.g. `MotorCADContext.magnetic`, `MotorCADContext.thermal`, `MotorCADContext.mechanical`).
- For Motor-CAD 2027.1+ (when the `do_weight_calculation_with_context` feature exists), the new `DoWeightCalculationWithContext` RPC method is called with the supplied context.
- If no context is provided (empty string) on a version that supports it, a `MotorCADWarning` is raised — this is consistent with the pattern used in `check_if_geometry_is_valid` and is required for headless-mode compatibility.
- For older Motor-CAD versions, falls back to the original `DoWeightCalculation` call with no parameters.

**test_calculations.py**
- `test_do_weight_calculation` now passes `MotorCADContext.magnetic` and `MotorCADContext.thermal` when running against Motor-CAD 2027.0+, and falls back to the no-argument call for older versions.
