### PR TITLE
Rename automation environment variable

### DIFF
--- a/src/ansys/motorcad/core/rpc_client_core.py
+++ b/src/ansys/motorcad/core/rpc_client_core.py
@@ -144,11 +144,16 @@ def _find_motor_cad_exe():
     )
 
     # Find Motor-CAD exe
-    motor_batch_file_path = environ.get("MOTORCAD_ACTIVEX")
+    motor_batch_file_path = environ.get("MOTORCAD_AUTOMATION")
+
+    # If MOTORCAD_AUTOMATION does not exist, try MOTORCAD_ACTIVEX
+    # For backwards compatibility
+    if motor_batch_file_path is None:
+        motor_batch_file_path = environ.get("MOTORCAD_ACTIVEX")
 
     if motor_batch_file_path is None:
         raise MotorCADError(
-            "Failed to retrieve MOTORCAD_ACTIVEX environment variable. " + str_alt_method
+            "Failed to retrieve MOTORCAD_AUTOMATION environment variable. " + str_alt_method
         )
 
     try:
@@ -159,7 +164,7 @@ def _find_motor_cad_exe():
         raise MotorCADError("Failed to get file path. " + str(e) + str_alt_method)
 
     try:
-        # Grab MotorCAD exe from activex batch file
+        # Grab MotorCAD exe from automation batch file
         motor_batch_file = open(motor_batch_file_path, "r")
 
         motor_batch_file_lines = motor_batch_file.readlines()

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ extras = tests
 commands =
     pytest {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
 passenv =
-    MOTORCAD_ACTIVEX
+    MOTORCAD_AUTOMATION
     ANSYSLMD_LICENSE_FILE
 
 [testenv:style]

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ commands =
     pytest {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
 passenv =
     MOTORCAD_AUTOMATION
+    MOTORCAD_ACTIVEX
     ANSYSLMD_LICENSE_FILE
 
 [testenv:style]

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ commands =
     pytest {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
 passenv =
     MOTORCAD_AUTOMATION
+;   MOTORCAD_ACTIVEX required for compatibility with test runners running on pre-27R1 versions of motorCAD
     MOTORCAD_ACTIVEX
     ANSYSLMD_LICENSE_FILE
 


### PR DESCRIPTION
Updates pymotorcad automation environment variable default to MOTORCAD_AUTOMATION
Keeps MOTORCAD_ACTIVEX so future versions of pymotorcad can still be used with old versions of motor-CAD.