### PR TITLE
Add set and get array variables as list methods

### DIFF
--- a/src/ansys/motorcad/core/methods/rpc_methods_variables.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_variables.py
@@ -110,6 +110,40 @@ class _RpcMethodsVariables:
         params = [array_name, array_index]
         return self.connection.send_and_receive(method, params)
 
+    def get_array_variable_list(self, array_name):
+        """Get the full array of a Motor-CAD array variable as a list.
+
+        Parameters
+        ----------
+        array_name : str
+            Name of the array
+
+        Returns
+        -------
+        list of int|float|str|bool
+            List of values of the Motor-CAD variable
+        """
+        # Get the array variable as a single string, delimited by colon. Split this string into a
+        # list.
+        value_string = self.get_variable(array_name)
+        value_string = value_string.split(":")
+        # Get the first variable of the array, and determine the type of the variable.
+        value_0 = self.get_array_variable(array_name, 0)
+        value_type = str
+        if isinstance(value_0, int):
+            value_type = int
+        if isinstance(value_0, float):
+            value_type = float
+        if isinstance(value_0, bool):
+            value_type = bool
+        # Create a list and append each value to the list. Convert the value if the value_type is
+        # not string.
+        values = []
+        if value_type is not None:
+            for value in value_string:
+                values.append(value_type(value))
+        return values
+
     def set_variable(self, variable_name, variable_value):
         """Set a Motor-CAD variable.
 
@@ -139,6 +173,50 @@ class _RpcMethodsVariables:
         method = "SetArrayVariable"
         params = [array_name, array_index, {"variant": variable_value}]
         return self.connection.send_and_receive(method, params)
+
+    def set_array_variable_list(self, array_name, variable_list):
+        """Set the full array of a Motor-CAD array variable as a list.
+
+        If a single value is provided, every element of the array will be set to this value.
+
+        Parameters
+        ----------
+        array_name : str
+            Name of the array
+        variable_list : list of int|float|str|bool
+            Values to set the variables to.
+        """
+        # Get the original array variable to determine the length of the array
+        values_orig = self.get_variable(array_name)
+        values_orig = values_orig.split(":")
+
+        # If the provided list of variables is longer than the original array, raise an error.
+        if isinstance(variable_list, list) and len(variable_list) > len(values_orig):
+            raise ValueError(
+                f"The array variable {array_name} has length = {len(values_orig)}. The "
+                f"variable_list provided has length = "
+                f"{len(variable_list)}. Please provide a list of {len(values_orig)} "
+                f"values."
+            )
+        # If a single value is provided, set all values of the array to the same value. Use the
+        # original length of the array to determine the number of values to add.
+        elif not isinstance(variable_list, list):
+            single_value = True
+            num_values = len(values_orig)
+        # If the provided list of variables is shorter than the original array, set the first n
+        # values of the array to the provided values, where n is the length of the provided list.
+        # Use the length of the provided list to determine the number of values to add.
+        else:
+            single_value = False
+            num_values = len(variable_list)
+
+        # Loop through all elements of the array, setting the value for each index
+        for i in range(num_values):
+            if not single_value:
+                value = variable_list[i]
+            else:
+                value = variable_list
+            self.set_array_variable(array_name, i, value)
 
     def get_file_name(self):
         """Get current .mot file name and path.

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -92,6 +92,16 @@ def test_get_array_variable(mc):
     assert isinstance(var, bool)
 
 
+def test_get_array_variable_list(mc):
+    reset_to_default_file(mc)
+    mc.set_variable("AxialSliceDefinition", 4)
+    mc.set_variable("ThroughVentilation", 1)
+    var = mc.get_array_variable_list("h_Adjust_TVent_Airgap_Stator")
+    assert isinstance(var, list)
+    assert len(var) == 9
+    assert isinstance(var[0], int)
+
+
 def test_set_array_variable(mc):
     # Float
     mc.set_array_variable("Duty_Cycle_Time", 2, 30)
@@ -107,6 +117,31 @@ def test_set_array_variable(mc):
     mc.set_array_variable("CustomOutputEnabled_Python", 2, True)
     var = mc.get_array_variable("CustomOutputEnabled_Python", 2)
     assert var is True
+
+
+def test_set_array_variable_list(mc):
+    reset_to_default_file(mc)
+    mc.set_variable("AxialSliceDefinition", 4)
+    mc.set_variable("ThroughVentilation", 1)
+    # set based on a single value
+    mc.set_array_variable_list("Calc_Input_h_TVent_Airgap_Stator", 1)
+    var = mc.get_array_variable_list("Calc_Input_h_TVent_Airgap_Stator")
+    assert isinstance(var, list)
+    assert len(var) == 9
+    assert isinstance(var[0], int)
+    for value in var:
+        assert value == 1
+    # set multiple values
+    new_values = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    mc.set_array_variable_list("h_Input_TVent_Airgap_Stator", new_values)
+    var = mc.get_array_variable_list("h_Input_TVent_Airgap_Stator")
+    assert isinstance(var, list)
+    assert len(var) == 9
+    assert isinstance(var[0], int)
+    for i in range(len(var)):
+        assert var[i] == new_values[i]
+
+    print("hello")
 
 
 def test_get_set_array_variable_2d(mc):


### PR DESCRIPTION
New methods for setting and getting array variables. Allows the variable values to be directly provided or returned as a list object. Previously only individual variables could be accessed. 

Also allows simple setting of every element in an array variable to the same value.

@jgsdavies could this be done instead inside Motor-CAD and exposed as a new API call? Would negate the need for multiple API calls.