### PR TITLE
Remove support for deprecated Python 3.9

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Build wheelhouse and perform smoke test
         uses: ansys/actions/build-wheelhouse@v10
@@ -55,8 +55,6 @@ jobs:
           library-name: ${{ env.LIBRARY_NAME }}
           operating-system: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
-          # License check requires 3.10 or above
-          check-licenses: ${{ matrix.python-version != '3.9' }}
 
   tests:
     name: Tests and coverage

--- a/.github/workflows/nightly-motorcad-check.yml
+++ b/.github/workflows/nightly-motorcad-check.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
       fail-fast: false
 

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -25,7 +25,7 @@ Installation
 
 Python module
 --------------
-The ``ansys.motorcad.core`` package currently supports Python 3.9 through Python 3.14 on Windows.
+The ``ansys.motorcad.core`` package currently supports Python 3.10 through Python 3.14 on Windows.
 
 Install the latest release from
 `PyPi <https://pypi.org/project/ansys-motorcad-core/>`_ with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name="ansys-motorcad-core"
 version = "0.9.dev0"
 description = "Pythonic interface to Ansys Motor-CAD."
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {file = "LICENSE"}
 authors = [
     {name = "ANSYS, Inc.", email = "pyansys.core@ansys.com"},
@@ -21,7 +21,6 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
     "License :: OSI Approved :: MIT License",
     "Operating System :: Microsoft :: Windows",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ isolated_build_env = build
 [gh-actions]
 description = The tox environment to be executed in gh-actions for a given python version
 python =
-    3.9: style,py39-coverage
     3.10: style,py310-coverage,doc
     3.11: style,py311-coverage,doc
     3.12: style,py312-coverage,doc
@@ -19,7 +18,6 @@ python =
 [testenv]
 description = Checks for project unit tests and coverage (if desired)
 basepython =
-    py39: python3.9
     py310: python3.10
     py311: python3.11
     py312: python3.12


### PR DESCRIPTION
Python 3.9 has gone past EOL. Remove support