### PR TITLE
Updated test_get_region_dxf to check load_dxf_file_with_context

### DIFF
--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -223,7 +223,10 @@ def test_get_region(mc):
 
 
 def test_get_region_dxf(mc):
-    mc.load_dxf_file(get_dir_path() + r"\test_files\dxf_import.dxf")
+    if mc.connection.check_if_feature_exists("load_dxf_file_with_context"):
+        mc.load_dxf_file(get_dir_path() + r"\test_files\dxf_import.dxf", "Magnetic")
+    else:
+        mc.load_dxf_file(get_dir_path() + r"\test_files\dxf_import.dxf")
     expected_region = geometry.Region(region_type=RegionType.dxf_import)
     expected_region.name = "DXFRegion_Rotor"
     expected_region.colour = (192, 192, 192)


### PR DESCRIPTION
Test uses mc.load_dxf_file which needs to pass a context in the newest release. This checks if the feature exists and if so passes the context.