### PR TITLE
Deprecate get_licence functions

### DIFF
--- a/src/ansys/motorcad/core/methods/rpc_methods_general.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_general.py
@@ -494,7 +494,7 @@ class _RpcMethodsGeneral:
           This method is deprecated. License is checked out at startup.
         """
         if self.connection.check_version_at_least("2027.1"):
-            print('get_licence is deprecated for 27R1 or later. License is checked out at startup.')
+            print("get_licence is deprecated for 27R1 or later. License is checked out at startup.")
         else:
             method = "GetLicence"
             return self.connection.send_and_receive(method)

--- a/src/ansys/motorcad/core/methods/rpc_methods_general.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_general.py
@@ -490,9 +490,15 @@ class _RpcMethodsGeneral:
         """Check if a license is available for the current context and machine type.
 
         If such a license is available, it is checked out.
+        
+        ..note::
+          This method is deprecated. License is checked out at startup.
         """
-        method = "GetLicence"
-        return self.connection.send_and_receive(method)
+        if self.connection.check_version_at_least("2027.1"):
+            print('get_licence is deprecated for 27R1 or later. License is checked out at startup.')
+        else:
+            method = "GetLicence"
+            return self.connection.send_and_receive(method)
 
     def get_license(self):
         """Check if a license is available for the current context and machine type.

--- a/src/ansys/motorcad/core/methods/rpc_methods_general.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_general.py
@@ -490,12 +490,12 @@ class _RpcMethodsGeneral:
         """Check if a license is available for the current context and machine type.
 
         If such a license is available, it is checked out.
-        
+
         ..note::
           This method is deprecated. License is checked out at startup.
         """
         if self.connection.check_version_at_least("2027.1"):
-            print('get_licence is deprecated for 27R1 or later. License is checked out at startup.')
+            print("get_licence is deprecated for 27R1 or later. License is checked out at startup.")
         else:
             method = "GetLicence"
             return self.connection.send_and_receive(method)

--- a/src/ansys/motorcad/core/methods/rpc_methods_general.py
+++ b/src/ansys/motorcad/core/methods/rpc_methods_general.py
@@ -490,7 +490,6 @@ class _RpcMethodsGeneral:
         """Check if a license is available for the current context and machine type.
 
         If such a license is available, it is checked out.
-        
         ..note::
           This method is deprecated. License is checked out at startup.
         """


### PR DESCRIPTION
The functions get_licence and get_license both do not do anything as the Motor-CAD licence is checked out during startup. Deprecate the functions so that old scripts still work.