### PR TITLE
Document which PyMotorCAD commands are available for Linux 

### DIFF
--- a/doc/source/user_guide/index.rst
+++ b/doc/source/user_guide/index.rst
@@ -4,10 +4,10 @@ User guide
 ============
 .. toctree::
    :maxdepth: 1
-   :hidden:
 
    internal_scripting
    external_scripting
+   linux_scripting
    matlab_scripting
    backwards_compatibility
    troubleshooting
@@ -42,6 +42,12 @@ the command line or via scripts from a Python IDE of your choice.
 For more information on using PyMotorCAD with an external Python installation, see :ref:`ref_external_scripting`.
 
 PyMotorCAD can also be used in MATLAB, for information on this, see :ref:`ref_matlab_scripting`.
+
+Using PyMotorCAD scripts for Linux
+-----------------------------------
+
+PyMotorCAD scripts can be used with Motor-CAD on Linux from 27R1. For more information,
+see :ref:`ref_linux_scripting`.
 
 Adaptive templates scripts
 --------------------------

--- a/doc/source/user_guide/linux_scripting.rst
+++ b/doc/source/user_guide/linux_scripting.rst
@@ -122,8 +122,8 @@ Available in Linux from 27R1
 
 
 
-Work In Progress
--------------------------------------
+Work in progress
+----------------
 
 .. check_collisions is in progress
 - ``build_model_lab``
@@ -138,14 +138,15 @@ Work In Progress
 - ``update_force_analysis_results``
 
 
-Unsupported Functionality
---------------------------
+Unsupported
+-----------
 
 - ``clear_messages``
 - ``disable_error_messages``
 - ``disable_popups``
 - ``disable_verbose_messages``
 - ``display_screen``
+- ``do_slot_finite_element``
 - ``enable_popups``
 - ``enable_verbose_messages``
 - ``export_figure_lab``
@@ -157,7 +158,6 @@ Unsupported Functionality
 - ``get_popups_enabled``
 - ``get_region_value``
 - ``get_verbose_messages_enabled``
-- ``go_slot_finite_element``
 - ``initialise_tab_names``
 - ``load_results``
 - ``run_script``

--- a/doc/source/user_guide/linux_scripting.rst
+++ b/doc/source/user_guide/linux_scripting.rst
@@ -1,0 +1,32 @@
+.. _ref_linux_scripting:
+
+Using PyMotorCAD scripts for Linux
+==================================
+
+PyMotorCAD scripts can be used with Motor-CAD on Linux from 27R1. This page provides
+an overview of command availability and acts as a placeholder for more detailed Linux
+scripting guidance.
+
+Available in Linux from 27R1
+----------------------------
+
+- ``placeholder_available_command_one``
+- ``placeholder_available_command_two``
+
+Not yet available in Linux as of 27R1
+-------------------------------------
+
+- ``placeholder_unavailable_command_one``
+- ``placeholder_unavailable_command_two``
+
+Not planned for Linux
+---------------------
+
+- ``placeholder_unplanned_command_one``
+- ``placeholder_unplanned_command_two``
+
+Not yet tested commands
+-----------------------
+
+- ``placeholder_command_one``
+- ``placeholder_command_two``

--- a/doc/source/user_guide/linux_scripting.rst
+++ b/doc/source/user_guide/linux_scripting.rst
@@ -77,8 +77,10 @@ Available in Linux from 27R1
 - ``load_adaptive_script``
 - ``load_custom_drive_cycle``
 - ``load_duty_cycle``
+- ``load_dxf_file``
 - ``load_external_model_lab``
 - ``load_fea_result``
+- ``load_from_file``
 - ``load_magnetisation_curves``
 - ``load_nvh_custom_response``
 - ``load_script``
@@ -115,43 +117,57 @@ Available in Linux from 27R1
 - ``subtract_region``
 - ``unite_regions``
 - ``upload_mot_file``
+- ``quit``
 
 
 
 
-Not yet available in Linux as of 27R1
+Work In Progress
 -------------------------------------
 
 .. check_collisions is in progress
+- ``build_model_lab``
 - ``check_collisions``
+- ``export_to_ansys_discovery``
+- ``export_to_ansys_electronics_desktop``
 - ``get_license``
 - ``get_magnetic_graph_harmonics``
-.. quit is in review
-- ``quit``
+- ``get_region_loss``
+- ``load_template``
+- ``save_fea_data``
 - ``update_force_analysis_results``
 
 
-Not planned for Linux 27R1
+Unsupported Functionality
 --------------------------
 
+- ``clear_messages``
+- ``disable_error_messages``
+- ``disable_popups``
+- ``disable_verbose_messages``
+- ``display_screen``
+- ``enable_popups``
+- ``enable_verbose_messages``
 - ``export_figure_lab``
 - ``export_force_animation``
 - ``export_results``
 - ``get_force_frequency_domain_amplitude``
 - ``get_messages``
+- ``get_popup_display_level``
+- ``get_popups_enabled``
 - ``get_region_value``
+- ``get_verbose_messages_enabled``
 - ``go_slot_finite_element``
+- ``initialise_tab_names``
 - ``load_results``
 - ``run_script``
-
-Not yet tested commands
------------------------
-
-- ``build_model_lab``
-- ``export_to_ansys_discovery``
-- ``export_to_ansys_electronics_desktop``
-- ``get_region_loss``
-- ``load_dxf_file``
-- ``load_from_file``
-- ``load_template``
-- ``save_fea_data``
+- ``save_motorcad_screen_to_file``
+- ``save_screen_to_file``
+- ``set_3d_component_visibility``
+- ``set_motorlab_context``
+- ``set_popup_display_level``
+- ``set_visible``
+- ``show_magnetic_context``
+- ``show_mechanical_context``
+- ``show_message``
+- ``show_thermal_context``

--- a/doc/source/user_guide/linux_scripting.rst
+++ b/doc/source/user_guide/linux_scripting.rst
@@ -4,29 +4,154 @@ Using PyMotorCAD scripts for Linux
 ==================================
 
 PyMotorCAD scripts can be used with Motor-CAD on Linux from 27R1. This page provides
-an overview of command availability and acts as a placeholder for more detailed Linux
-scripting guidance.
+an overview of command availability.
 
 Available in Linux from 27R1
 ----------------------------
 
-- ``placeholder_available_command_one``
-- ``placeholder_available_command_two``
+- ``add_external_custom_loss``
+- ``add_internal_custom_loss``
+- ``calculate_duty_cycle_lab``
+- ``calculate_force_harmonics_spatial``
+- ``calculate_force_harmonics_temporal``
+- ``calculate_generator_lab``
+- ``calculate_im_saturation_model``
+- ``calculate_iron_loss_coefficients``
+- ``calculate_magnet_parameters``
+- ``calculate_magnetic_lab``
+- ``calculate_operating_point_lab``
+- ``calculate_saturation_map``
+- ``calculate_test_performance_lab``
+- ``calculate_thermal_lab``
+- ``calculate_torque_envelope``
+- ``check_if_geometry_is_valid``
+- ``clear_duty_cycle``
+- ``clear_message_log``
+- ``clear_model_build_lab``
+- ``create_winding_pattern``
+- ``delete_region``
+- ``delete_solid_material``
+- ``do_magnetic_calculation``
+- ``do_magnetic_thermal_calculation``
+- ``do_mechanical_calculation``
+- ``do_multi_force_calculation``
+- ``do_steady_state_analysis``
+- ``do_transient_analysis``
+- ``do_weight_calculation``
+- ``download_mot_file``
+- ``edit_region_magnet``
+- ``export_concept_ev_model``
+- ``export_duty_cycle_lab``
+- ``export_lab_model``
+- ``export_matrices``
+- ``export_multi_force_data``
+- ``export_nvh_results_data``
+- ``export_solid_material``
+- ``geometry_export``
+- ``get_adaptive_parameter_value``
+- ``get_array_variable``
+- ``get_array_variable_2d``
+- ``get_component_material``
+- ``get_datastore``
+- ``get_fea_graph``
+- ``get_fea_graph_point``
+- ``get_file_name``
+- ``get_geometry_tree``
+- ``get_heatflow_graph``
+- ``get_magnetic_3d_graph``
+- ``get_magnetic_3d_graph_point``
+- ``get_magnetic_graph``
+- ``get_magnetic_graph_harmonics``
+- ``get_magnetic_graph_point``
+- ``get_model_built_lab``
+- ``get_point_value``
+- ``get_power_graph``
+- ``get_power_graph_point``
+- ``get_region``
+- ``get_region_dxf``
+- ``get_temperature_graph``
+- ``get_temperature_graph_point``
+- ``get_variable``
+- ``get_winding_coil``
+- ``import_solid_material``
+- ``load_adaptive_script``
+- ``load_custom_drive_cycle``
+- ``load_duty_cycle``
+- ``load_external_model_lab``
+- ``load_fea_result``
+- ``load_magnetisation_curves``
+- ``load_nvh_custom_response``
+- ``load_script``
+- ``load_winding_pattern``
+- ``remove_external_custom_loss``
+- ``remove_internal_custom_loss``
+- ``reset_adaptive_geometry``
+.. restore_compatibility_settings is to be renamed restore_deprecated_settings.
+- ``restore_compatibility_settings``
+- ``save_adaptive_script``
+- ``save_duty_cycle``
+- ``save_iron_loss_coefficients``
+- ``save_magnet_parameters``
+- ``save_results``
+- ``save_script``
+- ``save_template``
+- ``save_to_file``
+- ``save_winding_pattern``
+- ``select_material_database``
+- ``set_adaptive_parameter_default``
+- ``set_adaptive_parameter_value``
+- ``set_array_variable``
+- ``set_array_variable_2d``
+- ``set_component_material``
+- ``set_fea_path_arc``
+- ``set_fea_path_line``
+- ``set_fea_path_point``
+- ``set_fluid``
+- ``set_free``
+- ``set_geometry_tree``
+- ``set_region``
+- ``set_variable``
+- ``set_winding_coil``
+- ``subtract_region``
+- ``unite_regions``
+- ``upload_mot_file``
+
+
+
 
 Not yet available in Linux as of 27R1
 -------------------------------------
 
-- ``placeholder_unavailable_command_one``
-- ``placeholder_unavailable_command_two``
+.. check_collisions is in progress
+- ``check_collisions``
+- ``get_license``
+- ``get_magnetic_graph_harmonics``
+.. quit is in review
+- ``quit``
+- ``update_force_analysis_results``
 
-Not planned for Linux
----------------------
 
-- ``placeholder_unplanned_command_one``
-- ``placeholder_unplanned_command_two``
+Not planned for Linux 27R1
+--------------------------
+
+- ``export_figure_lab``
+- ``export_force_animation``
+- ``export_results``
+- ``get_force_frequency_domain_amplitude``
+- ``get_messages``
+- ``get_region_value``
+- ``go_slot_finite_element``
+- ``load_results``
+- ``run_script``
 
 Not yet tested commands
 -----------------------
 
-- ``placeholder_command_one``
-- ``placeholder_command_two``
+- ``build_model_lab``
+- ``export_to_ansys_discovery``
+- ``export_to_ansys_electronics_desktop``
+- ``get_region_loss``
+- ``load_dxf_file``
+- ``load_from_file``
+- ``load_template``
+- ``save_fea_data``

--- a/doc/source/user_guide/linux_scripting.rst
+++ b/doc/source/user_guide/linux_scripting.rst
@@ -125,7 +125,6 @@ Available in Linux from 27R1
 Work In Progress
 -------------------------------------
 
-.. check_collisions is in progress
 - ``build_model_lab``
 - ``check_collisions``
 - ``export_to_ansys_discovery``


### PR DESCRIPTION
Adds a page to the User Guide with a list of which commands are available for Linux for 27R1, which are not available for 27R1 and which have not yet been tested. 