### PR TITLE
Fix for pytests hanging and remove skip licencing tests

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -77,9 +77,13 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip tox tox-gh-actions
-          
+
       - name: Test with tox
         # Only the tox environment specified in the tox.ini gh-actions is run
+        # Licensing tests are excluded here as they manage their own Motor-CAD
+        # instances/licence types and can interfere with the shared test fixtures.
+        env:
+          PYTEST_MARKERS: -m "not licensing"
         run: tox -e py312-coverage
         
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,12 +19,10 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-import logging
-
 import pytest
 
 from RPC_Test_Common import reset_temp_file_folder, reset_to_default_file
-from ansys.motorcad.core import MotorCAD, MotorCADError
+from ansys.motorcad.core import MotorCAD
 
 
 def pytest_sessionstart(session):
@@ -44,11 +42,7 @@ def mc():
 
     yield motorcad_instance
 
-    try:
-        motorcad_instance.quit()
-    except MotorCADError:
-        # Process may have already crashed/exited - nothing left to clean up
-        logging.warning("Failed to quit Motor-CAD instance in 'mc' fixture teardown", exc_info=True)
+    motorcad_instance.quit()
 
 
 @pytest.fixture(scope="function")
@@ -71,10 +65,4 @@ def mc_fea_old():
 
     yield motorcad_instance_fea_old
 
-    try:
-        motorcad_instance_fea_old.quit()
-    except MotorCADError:
-        # Process may have already crashed/exited - nothing left to clean up
-        logging.warning(
-            "Failed to quit Motor-CAD instance in 'mc_fea_old' fixture teardown", exc_info=True
-        )
+    motorcad_instance_fea_old.quit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,10 @@ def mc():
     """Set up test environment for whole unit of tests"""
     motorcad_instance = MotorCAD()
     # Disable messages if opened with UI
-    motorcad_instance.disable_popups()
+    if motorcad_instance.connection.check_if_feature_exists("motor_cad_messager"):
+        motorcad_instance.disable_popups()
+    else:
+        motorcad_instance.set_variable("MessageDisplayState", 2)
     reset_to_default_file(motorcad_instance)
 
     yield motorcad_instance
@@ -54,7 +57,10 @@ def mc_fea_old():
     """Old fea geometry tests cause lots of conflicts - use a new MotorCAD"""
     motorcad_instance_fea_old = MotorCAD()
     # Disable messages if opened with UI
-    motorcad_instance_fea_old.disable_popups()
+    if motorcad_instance_fea_old.connection.check_if_feature_exists("motor_cad_messager"):
+        motorcad_instance_fea_old.disable_popups()
+    else:
+        motorcad_instance_fea_old.set_variable("MessageDisplayState", 2)
     reset_to_default_file(motorcad_instance_fea_old)
 
     yield motorcad_instance_fea_old

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,10 +19,12 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import logging
+
 import pytest
 
 from RPC_Test_Common import reset_temp_file_folder, reset_to_default_file
-from ansys.motorcad.core import MotorCAD
+from ansys.motorcad.core import MotorCAD, MotorCADError
 
 
 def pytest_sessionstart(session):
@@ -42,7 +44,11 @@ def mc():
 
     yield motorcad_instance
 
-    motorcad_instance.quit()
+    try:
+        motorcad_instance.quit()
+    except MotorCADError:
+        # Process may have already crashed/exited - nothing left to clean up
+        logging.warning("Failed to quit Motor-CAD instance in 'mc' fixture teardown", exc_info=True)
 
 
 @pytest.fixture(scope="function")
@@ -65,4 +71,10 @@ def mc_fea_old():
 
     yield motorcad_instance_fea_old
 
-    motorcad_instance_fea_old.quit()
+    try:
+        motorcad_instance_fea_old.quit()
+    except MotorCADError:
+        # Process may have already crashed/exited - nothing left to clean up
+        logging.warning(
+            "Failed to quit Motor-CAD instance in 'mc_fea_old' fixture teardown", exc_info=True
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ def mc():
     """Set up test environment for whole unit of tests"""
     motorcad_instance = MotorCAD()
     # Disable messages if opened with UI
-    motorcad_instance.set_variable("MessageDisplayState", 2)
+    motorcad_instance.disable_popups()
     reset_to_default_file(motorcad_instance)
 
     yield motorcad_instance
@@ -54,7 +54,7 @@ def mc_fea_old():
     """Old fea geometry tests cause lots of conflicts - use a new MotorCAD"""
     motorcad_instance_fea_old = MotorCAD()
     # Disable messages if opened with UI
-    motorcad_instance_fea_old.set_variable("MessageDisplayState", 2)
+    motorcad_instance_fea_old.disable_popups()
     reset_to_default_file(motorcad_instance_fea_old)
 
     yield motorcad_instance_fea_old

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -118,29 +118,35 @@ def test_message_config(mc):
     if not mc.connection.check_if_feature_exists("motor_cad_messager"):
         pytest.skip("Motor-CAD Messager is not enabled, skipping test_message_config")
 
-    mc.disable_popups()
-    assert mc.get_popups_enabled() is False
-    mc.enable_popups()
-    assert mc.get_popups_enabled() is True
+    try:
+        mc.disable_popups()
+        assert mc.get_popups_enabled() is False
+        mc.enable_popups()
+        assert mc.get_popups_enabled() is True
 
-    mc.set_popup_display_level(MotorCADPopupDisplayLevel.info)
-    assert mc.get_popup_display_level() == MotorCADPopupDisplayLevel.info
-    mc.set_popup_display_level(MotorCADPopupDisplayLevel.error)
-    assert mc.get_popup_display_level() == MotorCADPopupDisplayLevel.error
-    mc.set_popup_display_level(MotorCADPopupDisplayLevel.warning)
-    assert mc.get_popup_display_level() == MotorCADPopupDisplayLevel.warning
-    mc.set_popup_display_level(MotorCADPopupDisplayLevel.fatal)
-    assert mc.get_popup_display_level() == MotorCADPopupDisplayLevel.fatal
+        mc.set_popup_display_level(MotorCADPopupDisplayLevel.info)
+        assert mc.get_popup_display_level() == MotorCADPopupDisplayLevel.info
+        mc.set_popup_display_level(MotorCADPopupDisplayLevel.error)
+        assert mc.get_popup_display_level() == MotorCADPopupDisplayLevel.error
+        mc.set_popup_display_level(MotorCADPopupDisplayLevel.warning)
+        assert mc.get_popup_display_level() == MotorCADPopupDisplayLevel.warning
+        mc.set_popup_display_level(MotorCADPopupDisplayLevel.fatal)
+        assert mc.get_popup_display_level() == MotorCADPopupDisplayLevel.fatal
+    finally:
+        mc.disable_popups()
 
 
 def test_verbose_message_config(mc):
     if not mc.connection.check_if_feature_exists("motor_cad_messager"):
         pytest.skip("Motor-CAD Messager is not enabled, skipping test_verbose_message_config")
 
-    mc.disable_verbose_messages()
-    assert mc.get_verbose_messages_enabled() is False
-    mc.enable_verbose_messages()
-    assert mc.get_verbose_messages_enabled() is True
+    try:
+        mc.disable_verbose_messages()
+        assert mc.get_verbose_messages_enabled() is False
+        mc.enable_verbose_messages()
+        assert mc.get_verbose_messages_enabled() is True
+    finally:
+        mc.disable_verbose_messages()
 
 
 def test_load_dxf_file():

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -218,3 +218,5 @@ def test_get_datastore(mc):
     }
 
     new_datastore = Datastore.from_dict(test_dict)
+
+    mc.enable_popups()

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -218,5 +218,3 @@ def test_get_datastore(mc):
     }
 
     new_datastore = Datastore.from_dict(test_dict)
-
-    assert mc.is_open()

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -219,4 +219,4 @@ def test_get_datastore(mc):
 
     new_datastore = Datastore.from_dict(test_dict)
 
-    mc.enable_popups()
+    assert mc.is_open()


### PR DESCRIPTION
Ensure motorcad is left in a state where popups/messages are turned off after test_message_config and test_verbose_message_config. Also update conftest.py to use new motorcad message config commands when the feature exists.

These seem to be have causing the issues with the tests.