### PR TITLE
Revert "Wait for MotorCAD process to quit correctly on Linux"

### DIFF
--- a/src/ansys/motorcad/core/rpc_client_core.py
+++ b/src/ansys/motorcad/core/rpc_client_core.py
@@ -902,45 +902,5 @@ class _MotorCADConnection:
             self.pim_instance.delete()
         else:
             # local machine
-            if not psutil.pid_exists(self.pid):
-                # The process has already exited, so send_and_recieve will fail.
-                # Possible that another MotorCAD object has already sent the Quit command,
-                # or the user has closed Motor-CAD.
-                raise MotorCADError(
-                    "Motor-CAD process has already exited. Cannot send Quit command."
-                )
-
             method = "Quit"
-            result = self.send_and_receive(method)
-
-            # Wait for the process to exit before returning from quit() and then kill the process
-            # if it doesn't exit within 60 seconds.
-            # The Motor-CAD process becomes a zombie process if it doesn't exit before the Python
-            # script exits.
-            if self.pid != -1:
-                # ping every second for a max of 60 seconds to force kill.
-                max_time = 60
-                for step in range(max_time):
-                    try:
-                        proc = psutil.Process(self.pid)
-                        proc.wait(timeout=1)
-                        # Process exited correctly after waiting.
-                        # If it didn't exceptions will be caught and the loop will continue to ping.
-                        return result
-                    except psutil.TimeoutExpired:
-                        # Process still exists, so wait for next ping
-                        continue
-                    except psutil.NoSuchProcess:
-                        # process exited correctly
-                        return result
-
-                # Process still exists after max_time seconds, so force kill it.
-                try:
-                    proc = psutil.Process(self.pid)
-                    proc.kill()
-                    proc.wait()
-
-                    raise MotorCADError("Motor-CAD process did not exit and was force killed.")
-                except psutil.NoSuchProcess:
-                    return result
-            return result
+            return self.send_and_receive(method)

--- a/tests/test_licence_params.py
+++ b/tests/test_licence_params.py
@@ -179,14 +179,11 @@ def test_existinginstance_withlicencetype():
     mc2 = MotorCAD(
         open_new_instance=False, use_new_license_type=True, show_gui=False, full_headless_beta=True
     )
-    try:
-        assert mc.is_open(), "Failed to open MotorCAD"
-        assert mc2.is_open()
-        assert mc2.get_licence() is None
-        mc2.get_messages(1)
-        if is_motorcad_gui_visible(mc2) == True:
-            assert True
-    finally:
-        # Do not call quit for mc2 as it is connected to the same process.
-        # it will already be closed when mc.quit() is called.
-        mc.quit()
+    assert mc.is_open(), "Failed to open MotorCAD"
+    assert mc2.is_open()
+    assert mc2.get_licence() is None
+    mc2.get_messages(1)
+    if is_motorcad_gui_visible(mc2) == True:
+        assert True
+    mc2.quit()
+    mc.quit()


### PR DESCRIPTION
Reverts ansys/pymotorcad#805 as causing some test problems