### PR TITLE
Don't change working directory when launching Motor-CAD

### DIFF
--- a/src/ansys/motorcad/core/rpc_client_core.py
+++ b/src/ansys/motorcad/core/rpc_client_core.py
@@ -609,8 +609,7 @@ class _MotorCADConnection:
             )
 
         motor_process = subprocess.Popen(
-            [self.__MotorExe, get_arg("PORT=" + str(self._port)), get_arg("SCRIPTING")],
-            cwd=Path(self.__MotorExe).parent.absolute(),
+            [self.__MotorExe, get_arg("PORT=" + str(self._port)), get_arg("SCRIPTING")]
         )
 
         pid = motor_process.pid


### PR DESCRIPTION
This should allow users to load files more easily using relative paths.