### PR TITLE
Update doc generation

### DIFF
--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,0 +1,1 @@
+source/_templates/generated

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,1 +1,8 @@
-source/_templates/generated
+# styles
+styles/*
+!styles/Vocab/
+!styles/Vocab/**
+!styles/.gitignore
+
+# templates
+source/_templates/generated/**

--- a/doc/source/_templates/README.md
+++ b/doc/source/_templates/README.md
@@ -1,1 +1,8 @@
 ## Contains templates for the documentation build
+
+`_templates/`
+ - `./README.md` this
+ - `./templates/` is for normal template files
+     - `./autogen/` is for _autogen files in `source/methods/`
+     - `./autosummary/` is for method files in `source/methods/_autosummary_[Category]/`
+ - `./generated/` is for generated template files, currently just used for unit category method templates

--- a/doc/source/_templates/README.md
+++ b/doc/source/_templates/README.md
@@ -3,6 +3,6 @@
 `_templates/`
  - `./README.md` this
  - `./templates/` is for normal template files
-     - `./autogen/` is for _autogen files in `source/methods/`
+     - `./autogen/` is for `_autogen` files in `source/methods/`
      - `./autosummary/` is for method files in `source/methods/_autosummary_[Category]/`
  - `./generated/` is for generated template files, currently just used for unit category method templates

--- a/doc/source/_templates/templates/autogen/default_category.rst_template
+++ b/doc/source/_templates/templates/autogen/default_category.rst_template
@@ -1,0 +1,13 @@
+.. _ref_[Category]_API:
+[Category]
+==============================
+
+.. currentmodule:: ansys.motorcad.core.motorcad_methods.MotorCAD
+
+.. autosummary::
+   :toctree: _autosummary_[Category]
+
+   :methods:
+
+   .. start of auto documentation - do not write past this line
+

--- a/doc/source/_templates/templates/autogen/unit_category.rst_template
+++ b/doc/source/_templates/templates/autogen/unit_category.rst_template
@@ -1,0 +1,16 @@
+.. _ref_[Category]_API:
+[Category]
+==============================
+
+``MotorCad.[unitname]``
+
+.. currentmodule:: ansys.motorcad.core.motorcad_methods.MotorCAD.[unitname]
+
+.. autosummary::
+   :toctree: _autosummary_[Category]
+   :template: generated/method_template_[Category].rst
+
+   :methods:
+
+   .. start of auto documentation - do not write past this line
+

--- a/doc/source/_templates/templates/autosummary/unit_method.rst_template
+++ b/doc/source/_templates/templates/autosummary/unit_method.rst_template
@@ -1,0 +1,7 @@
+{{ name | escape | underline }}
+
+``MotorCAD.[unitname].{{ name }}``
+
+.. currentmodule:: ansys.motorcad.core.motorcad_methods.MotorCAD
+
+.. automethod:: [unitname].{{ name }}

--- a/doc/source/methods/MotorCAD_object.rst
+++ b/doc/source/methods/MotorCAD_object.rst
@@ -28,4 +28,5 @@ MotorCAD API
    _autogen_UI
    _autogen_Utility
    _autogen_Variables
+   _autogen_Message Config
 

--- a/doc/source/methods/autofill_function_names.py
+++ b/doc/source/methods/autofill_function_names.py
@@ -12,6 +12,15 @@ import shutil
 #     _DocCategory obj.
 #  2. Run this script to generate the documentation files.
 #
+# If you are adding a Unit category spesificly, the rpc_methods_core python file will
+# need to be updated. A class attribute will need to be added and set to be an alias of
+# the rpc class, this attribute will share the name as the runtime instance used. This is
+# used by the doc gen to find the methods but has no functional impact when using the api.
+# e.g. for messageconfig, the runtime instance is referenced via MotorCad.messageconfig.<method>
+#      and is set to _RpcMessageConfig(mc_connection). Along with this there needs to be a
+#      _RpcMethodsCore.messageconfig attribute set to _RpcMessageConfig.
+# See messageconfig in rpc_methods_core for an example.
+#
 # If you are adding a new documentation category generation type, follow the steps:
 #  1. Add a new entry to the _DocCategoryGenType enumeration with the appropriate value.
 #  2. Update _DocCategory with any new fields required for the new generation type.

--- a/doc/source/methods/autofill_function_names.py
+++ b/doc/source/methods/autofill_function_names.py
@@ -10,7 +10,8 @@ import shutil
 # If you are adding a new documentation category, follow these steps :
 #  1. Add a new entry to the `doc_catagories` list with the appropriate values using a
 #     _DocCategory obj.
-#  2. Run this script to generate the documentation files.
+#  2. Add to doc/source/methods/MotorCAD_object.rst file
+#  3. Run this script to generate the documentation files.
 #
 # If you are adding a Unit category spesificly, the rpc_methods_core python file will
 # need to be updated. A class attribute will need to be added and set to be an alias of

--- a/doc/source/methods/autofill_function_names.py
+++ b/doc/source/methods/autofill_function_names.py
@@ -8,12 +8,12 @@ import shutil
 # FOR DEVELOPERS :
 #
 # If you are adding a new documentation category, follow these steps :
-#  1. Add a new entry to the `doc_catagories` list with the appropriate values using a
+#  1. Add a new entry to the `doc_categories` list with the appropriate values using a
 #     _DocCategory obj.
 #  2. Add to doc/source/methods/MotorCAD_object.rst file
 #  3. Run this script to generate the documentation files.
 #
-# If you are adding a Unit category spesificly, the rpc_methods_core python file will
+# If you are adding a Unit category specifically, the rpc_methods_core python file will
 # need to be updated. A class attribute will need to be added and set to be an alias of
 # the rpc class, this attribute will share the name as the runtime instance used. This is
 # used by the doc gen to find the methods but has no functional impact when using the api.
@@ -72,7 +72,7 @@ def generate_method_docs():
     #
     # See _DocCategoryGenType for structure
     #
-    doc_catagories = [
+    doc_categories = [
         _DocCategory(_DocCategoryGenType.default, "Calculations", "rpc_methods_calculations.py"),
         _DocCategory(_DocCategoryGenType.default, "FEA Geometry", "rpc_methods_fea_geometry.py"),
         _DocCategory(_DocCategoryGenType.default, "General", "rpc_methods_general.py"),
@@ -112,7 +112,7 @@ def generate_method_docs():
     templates_folder.mkdir(exist_ok=True)
 
     # Generate documentation for each category
-    for i, category in enumerate(doc_catagories):
+    for i, category in enumerate(doc_categories):
         # rpc methods python file path
         file_path = str(
             (

--- a/doc/source/methods/autofill_function_names.py
+++ b/doc/source/methods/autofill_function_names.py
@@ -1,7 +1,54 @@
 """Test script for generating docs for methods."""
+import ast
+from dataclasses import dataclass
+from enum import Enum
 import pathlib
-import re
 import shutil
+
+# FOR DEVELOPERS :
+#
+# If you are adding a new documentation category, follow these steps :
+#  1. Add a new entry to the `doc_catagories` list with the appropriate values using a
+#     _DocCategory obj.
+#  2. Run this script to generate the documentation files.
+#
+# If you are adding a new documentation category generation type, follow the steps:
+#  1. Add a new entry to the _DocCategoryGenType enumeration with the appropriate value.
+#  2. Update _DocCategory with any new fields required for the new generation type.
+#  3. Create any templates needed in _templates/templates/
+#  4. Update the replace_dict passed to _doctemplate_find_and_replace if needed for new
+#     _DocCategory fields.
+#  5. Update the generate_method_docs function to handle the new generation type if necessary.
+#  6. Test the documentation generation to ensure it works correctly with the new generation
+#     type.
+#  7. Update any comments related to the new documentation category or generation type. Also
+#     note the README in _templates/
+
+
+class _DocCategoryGenType(str, Enum):
+    """Provides an enumeration for doc category generation types."""
+
+    default = "default"  # MotorCAD.<method>
+    unit = "unit"  # MotorCAD.[unit].<method>
+
+
+@dataclass
+class _DocCategory:
+    category_type: _DocCategoryGenType
+    category_name: str
+    file_name: str
+    unit_name: str | None = None  # Only required for unit type categories
+
+
+def _doctemplate_find_and_replace(file_path: str, replace_dict: dict):
+    with open(file_path, "r") as doctemplate_file:
+        file_content = doctemplate_file.read()
+
+    for key, value in replace_dict.items():
+        file_content = file_content.replace(key, value)
+
+    with open(file_path, "w") as doctemplate_file:
+        doctemplate_file.write(file_content)
 
 
 def generate_method_docs():
@@ -9,92 +56,136 @@ def generate_method_docs():
 
     New categories also need adding in MotorCAD_object.rst
     """
-    function_categories = [
-        "Calculations",
-        "FEA Geometry",
-        "General",
-        "Geometry",
-        "Adaptive Geometry",
-        "Graphs",
-        "Internal Scripting",
-        "Lab",
-        "Materials",
-        "Thermal",
-        "UI",
-        "Utility",
-        "Variables",
+    # Docs can be generated in different ways depending on the category type :
+    # default   :   MotorCAD.<method>
+    # unit      :   MotorCAD.[unit].<method>
+    #
+    # See _DocCategoryGenType for structure
+    #
+    doc_catagories = [
+        _DocCategory(_DocCategoryGenType.default, "Calculations", "rpc_methods_calculations.py"),
+        _DocCategory(_DocCategoryGenType.default, "FEA Geometry", "rpc_methods_fea_geometry.py"),
+        _DocCategory(_DocCategoryGenType.default, "General", "rpc_methods_general.py"),
+        _DocCategory(_DocCategoryGenType.default, "Geometry", "rpc_methods_geometry.py"),
+        _DocCategory(_DocCategoryGenType.default, "Adaptive Geometry", "adaptive_geometry.py"),
+        _DocCategory(_DocCategoryGenType.default, "Graphs", "rpc_methods_graphs.py"),
+        _DocCategory(
+            _DocCategoryGenType.default, "Internal Scripting", "rpc_methods_internal_scripting.py"
+        ),
+        _DocCategory(_DocCategoryGenType.default, "Lab", "rpc_methods_lab.py"),
+        _DocCategory(_DocCategoryGenType.default, "Materials", "rpc_methods_materials.py"),
+        _DocCategory(_DocCategoryGenType.default, "Thermal", "rpc_methods_thermal.py"),
+        _DocCategory(_DocCategoryGenType.default, "UI", "rpc_methods_ui.py"),
+        _DocCategory(_DocCategoryGenType.default, "Utility", "rpc_methods_utility.py"),
+        _DocCategory(_DocCategoryGenType.default, "Variables", "rpc_methods_variables.py"),
+        _DocCategory(
+            _DocCategoryGenType.unit, "Message Config", "rpc_message_config.py", "messageconfig"
+        ),
     ]
 
-    file_names = [
-        "rpc_methods_calculations.py",
-        "rpc_methods_fea_geometry.py",
-        "rpc_methods_general.py",
-        "rpc_methods_geometry.py",
-        "adaptive_geometry.py",
-        "rpc_methods_graphs.py",
-        "rpc_methods_internal_scripting.py",
-        "rpc_methods_lab.py",
-        "rpc_methods_materials.py",
-        "rpc_methods_thermal.py",
-        "rpc_methods_ui.py",
-        "rpc_methods_utility.py",
-        "rpc_methods_variables.py",
-    ]
+    # Get file/dir paths , see README for template info
+    #
+    # current_folder      : .../pymotorcad/doc/source/methods/
+    # docsource_folder    : .../pymotorcad/doc/source/
+    # _templates_folder   : .../pymotorcad/doc/source/_templates/templates
+    # templates_folder    : .../pymotorcad/doc/source/_templates/generated
+    # parent_path         : .../pymotorcad/
+    #
+    current_folder = pathlib.Path(__file__).parent.resolve()
+    docsource_folder = current_folder.parent.resolve()
+    _templates_folder = docsource_folder / "_templates" / "templates"
+    templates_folder = docsource_folder / "_templates" / "generated"
+    parent_path = current_folder.parents[2].absolute()
 
-    for i in range(len(function_categories)):
-        category = function_categories[i]
-        file_name = file_names[i]
+    # Ensure template folders exist for templates to be generated into
+    _templates_folder.mkdir(exist_ok=True)
+    templates_folder.mkdir(exist_ok=True)
 
-        current_folder = pathlib.Path(__file__).parent.resolve()
-        parent_path = current_folder.parents[2].absolute()
-
+    # Generate documentation for each category
+    for i, category in enumerate(doc_catagories):
+        # rpc methods python file path
         file_path = str(
-            (parent_path / "src" / "ansys" / "motorcad" / "core" / "methods" / file_name).absolute()
+            (
+                parent_path / "src" / "ansys" / "motorcad" / "core" / "methods" / category.file_name
+            ).absolute()
         )
-        methods_file = open(file_path)
 
+        # Get functions
         func_names = []
+        with open(file_path, "r") as methods_file:
+            # filename arg only used for errors
+            tree = ast.parse(methods_file.read(), filename=file_path)
 
-        for line in methods_file:
-            # get function names from file
-            if ("    def" in line) and (not "def _" in line):
-                # Don't include internal functions
-                test = re.search("    def.*\(", line)
-                get_name = test.group()
+        # for node in ast.walk(tree):
+        #     if isinstance(node, ast.FunctionDef) and not node.name.startswith("_"):
+        #         func_names.append(node.name)
+        #
+        # If below isn't finding all the rpc methods try switching to the above for loop instead.
+        # It is less strict, allowing methods outside of the _Rpc class to be included.
+        # I used this one as a bit safer, but it does have the potential to be more restrictive.
+        #
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef) and node.name.startswith("_Rpc"):
+                func_names = [
+                    method.name
+                    for method in node.body
+                    if isinstance(method, (ast.FunctionDef, ast.AsyncFunctionDef))
+                    and not method.name.startswith("_")
+                ]
+                break
+        else:
+            raise ValueError(f"No class found in {file_path}")
 
-                # strip def and (
-                get_name = get_name[7:]
-                get_name = get_name[:-1]
+        func_names = sorted(func_names)  # sorted so more readable in the docs
 
-                func_names.append(get_name)
+        # Create method template for the category if it of the unit type
+        if category.category_type == _DocCategoryGenType.unit:
+            unit_method_template = str(
+                (_templates_folder / "autosummary" / "unit_method.rst_template").absolute()
+            )
+            new_unit_method_template_file = str(
+                (templates_folder / f"method_template_{category.category_name}.rst").absolute()
+            )
 
-        methods_file.close()
+            shutil.copyfile(unit_method_template, new_unit_method_template_file)
 
-        new_file_name = str((current_folder / ("_autogen_" + category + ".rst")).absolute())
-        # Copy template file
-        shutil.copyfile(str(current_folder / "template.rst_template"), new_file_name)
+            _doctemplate_find_and_replace(
+                new_unit_method_template_file,
+                {
+                    "[Category]": category.category_name,
+                    "[unitname]": category.unit_name,
+                },
+            )
 
-        # read file
-        doc_file = open(new_file_name, "r")
-        file_contents = doc_file.read()
+        # Create new documentation autogen file based on template
+        category_template = str(
+            (
+                _templates_folder
+                / "autogen"
+                / f"{category.category_type.value}_category.rst_template"
+            ).absolute()
+        )
+        new_category_template_file = str(
+            (current_folder / ("_autogen_" + category.category_name + ".rst")).absolute()
+        )
 
-        # replace some names/paths
-        file_contents = file_contents.replace("Category", category)
-        file_contents = file_contents.replace("_autosummary_path", "_autosummary_" + category)
-        doc_file.close()
+        shutil.copyfile(category_template, new_category_template_file)
 
-        # write title to file
-        doc_file = open(new_file_name, "w")
-        doc_file.write(file_contents)
-        doc_file.close()
+        # Prepare the dictionary for replacing placeholders in the new category autogen file
+        #  note: currently optional feilds in _DocCategory default to None, it throws an error if
+        #        you pass None to the replace_dict. So it may be better for it to default to None
+        #        a "" (empty string) instead of None to avoid many if statements to emit un-used
+        #        fields when in a category type not supporting those fields.
+        replace_dict = {"[Category]": category.category_name}
+        if category.category_type == _DocCategoryGenType.unit:
+            replace_dict["[unitname]"] = category.unit_name
 
-        # append to end of file
-        doc_file = open(new_file_name, "a")
+        _doctemplate_find_and_replace(new_category_template_file, replace_dict)
 
-        func_names = sorted(func_names)
-
-        for func_name in func_names:
-            doc_file.write("   " + func_name + "\n")
+        # append method names to end of category documentation file
+        with open(new_category_template_file, "a") as doc_file:
+            for func_name in func_names:
+                doc_file.write("   " + func_name + "\n")
 
 
 if __name__ == "__main__":

--- a/doc/styles/.gitignore
+++ b/doc/styles/.gitignore
@@ -1,4 +1,0 @@
-*
-!Vocab
-!Vocab/**
-!.gitignore


### PR DESCRIPTION
`autofill_function_names.py` is old and not built to support the new syntax of mc.[unit].<method>. With the addition of `mc.messageconfig.<method>` methods, the doc builder needed to be updated to support this and be future proofed a bit.

Changes :
 - Updated `autofill_function_names.py` script :
   - Now uses an array of _DocCategory dataclass to represent the categories instead of 2 lists
   - Added _DocCategoryGenType which can be expanded, this allows different categories to generate docs in different ways.
   - Added Unit categories, a new type which supports the `mc.messageconfig.<method>` synax
- Re-structured how templates work, now can be found in `.../doc/source/_templates` folder, contains a mix of static and generated templates used to generate the .rst files.
  - Added templates for default, unit categories and for unit methods.
- Updated comments to make additions in future easier